### PR TITLE
Fix - Increment number in Slate keygenerator function

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -21,9 +21,8 @@ class MyApp extends App {
 
   render() {
     const { store } = this.props;
-
+    let keyInt = 0;
     const keygen = () => {
-      let keyInt = 0;
       let keyString = `${Date.now().toString()}_${keyInt++}`;
       return keyString;
     };


### PR DESCRIPTION
### Problem

The `keyInt` wasn't being incremented and produced this error:
```
A node with a duplicate key of "1571842451212_0" was found! Duplicate keys are not allowed, you should use `node.regenerateKey` before inserting if you are reusing an existing node.
```

### Solution
Define `keyInt` inside of the `render` method because the `keygen` function does not have access to the local state updates from `MyApp`.

### Notes
See example here: https://github.com/zeit/next.js/blob/canary/examples/with-slate/lib/useCustomKeygen.js