### PR TITLE
Shim edit history

### DIFF
--- a/components/Paper/PaperEditHistory.js
+++ b/components/Paper/PaperEditHistory.js
@@ -56,11 +56,11 @@ class PaperEditHistory extends React.Component {
           onClick={() => this.changeEditView(index, edit.summary)}
         >
           <div className={css(styles.date)}>
-            {moment(edit.approved_at).format("MMM Do YYYY, h:mm A")}
+            {moment(edit.approvedDate).format("MMM Do YYYY, h:mm A")}
             {index === 0 && <span>{` (Current Ver.)`}</span>}
           </div>
           <div className={css(styles.user)}>
-            {`${edit.proposed_by.first_name} ${edit.proposed_by.last_name}`}
+            {`${edit.proposedBy.firstName} ${edit.proposedBy.lastName}`}
           </div>
         </div>
       );

--- a/pages/paper/[paperId]/[tabName]/edits/index.js
+++ b/pages/paper/[paperId]/[tabName]/edits/index.js
@@ -42,7 +42,7 @@ class PaperEditHistory extends React.Component {
     let editorState = convertToEditorValue(edit.summary);
 
     if (edit.previous) {
-      previousState = convertToEditorValue(edit.previous__summary);
+      previousState = convertToEditorValue(edit.previousSummary);
       editorState = this.diffVersions(editorState, previousState);
     }
 
@@ -61,7 +61,7 @@ class PaperEditHistory extends React.Component {
       let editorState = convertToEditorValue(edit.summary);
 
       if (edit.previous) {
-        previousState = convertToEditorValue(edit.previous__summary);
+        previousState = convertToEditorValue(edit.previousSummary);
         editorState = this.diffVersions(editorState, previousState);
       }
 
@@ -208,11 +208,11 @@ class PaperEditHistory extends React.Component {
           onClick={() => this.changeEditView(index, edit)}
         >
           <div className={css(styles.date)}>
-            {moment(edit.approved_at).format("MMM Do YYYY, h:mm A")}
+            {moment(edit.approvedDate).format("MMM Do YYYY, h:mm A")}
             {index === 0 && <span>{` (Current Ver.)`}</span>}
           </div>
           <div className={css(styles.user)}>
-            {`${edit.proposed_by.first_name} ${edit.proposed_by.last_name}`}
+            {`${edit.proposedBy.firstName} ${edit.proposedBy.lastName}`}
           </div>
         </div>
       );

--- a/redux/paper/index.js
+++ b/redux/paper/index.js
@@ -107,7 +107,7 @@ export const PaperActions = {
           return dispatch({
             type: types.GET_EDITS,
             payload: {
-              editHistory: resp,
+              editHistory: shims.editHistory(resp),
               doneFetching: true,
             },
           });

--- a/redux/paper/shims.js
+++ b/redux/paper/shims.js
@@ -41,6 +41,12 @@ export const paperPost = ({
   return formData;
 };
 
+export const editHistory = (editHistory) => {
+  return editHistory.map((edit) => {
+    return transformEdit(edit);
+  });
+};
+
 export const paperSummaryPost = ({ paperId, text }) => {
   return {
     paper: paperId,
@@ -65,4 +71,19 @@ function transformThreads(threads) {
     score: thread.score,
     userVote: transformVote(thread.user_vote),
   }));
+}
+
+function transformEdit(edit) {
+  return {
+    id: edit.id,
+    proposedBy: transformUser(edit.proposed_by),
+    summary: edit.summary,
+    previousSummary: edit.previous__summary,
+    approved: edit.approved,
+    approvedBy: transformUser(edit.approved_by),
+    approvedDate: edit.approved_date,
+    createdDate: edit.created_date,
+    updatedDate: edit.updated_date,
+    paper: edit.paper,
+  };
 }


### PR DESCRIPTION
### What code is changing?

Instead of using the backend field names, the editHistory items are passed through a shim so the clientside can use its own field names. In particular this is useful because we changed the `_at` fields to `_date` on the backend.