### PR TITLE
downgrade confetti

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "react-avatar": "^3.7.0",
     "react-avatar-edit": "^0.8.3",
     "react-burger-menu": "^2.6.11",
-    "react-confetti": "^5.0.1",
+    "react-confetti": "4.0.1",
     "react-device-detect": "^1.9.10",
     "react-dom": "^16.10.1",
     "react-dropzone": "^10.1.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5477,10 +5477,10 @@ react-burger-menu@^2.6.11:
     prop-types "^15.7.2"
     snapsvg-cjs "0.0.6"
 
-react-confetti@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/react-confetti/-/react-confetti-5.0.1.tgz#3003570778cafad4db0ab5513018d4c10e9d1271"
-  integrity sha512-mMxg2JPiRynzWEcfdsUVciRSKr2Mm3pFVKSGng/9Rgg1fYLxVj5XgSqiCP7kz2fN8/xfC79Rbgp1JRyCYssBkA==
+react-confetti@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/react-confetti/-/react-confetti-4.0.1.tgz#f9e76b198ce02f1c13809a1d1ec1bc92f5450dde"
+  integrity sha512-uQrb1Q4p8Wg3xyxSGtsIxdd+hOd3jRNpVq5qET6m9B+fihsjF7mHbMngoiziya3DZtstaqCBPpTcyByXLu8CnQ==
   dependencies:
     tween-functions "^1.2.0"
 


### PR DESCRIPTION
Downgrade 'react-confetti' from 5.0.1 to 4.0.1 to have it work with server-side rendering.

More details about the issue here:
https://github.com/alampros/react-confetti/issues/76