### PR TITLE
Paper Progress Loading Behavior

### DIFF
--- a/components/Paper/PaperProgress.js
+++ b/components/Paper/PaperProgress.js
@@ -493,6 +493,7 @@ const styles = StyleSheet.create({
   maintext: {
     color: "#5a566a",
     minHeight: 36,
+    transition: "all ease-in-out 0.2s",
     "@media only screen and (max-width: 800px)": {
       fontSize: 14,
     },

--- a/pages/paper/[paperId]/[tabName]/index.js
+++ b/pages/paper/[paperId]/[tabName]/index.js
@@ -117,7 +117,6 @@ const Paper = (props) => {
         setReferencedBy(newReferencedBy);
         setReferencedByCount(res.count);
         setDoneCitations(true);
-        console.log("fetched references");
       });
   };
 
@@ -130,7 +129,6 @@ const Paper = (props) => {
         setFigureCount(res.data.length);
         dispatch(PaperActions.updatePaperState("figures", res.data));
         setDoneFigures(true);
-        console.log("fetched figures");
       });
   };
 


### PR DESCRIPTION
**Feature**

1. Hide Paper Progress Component while waiting for API calls for metadata to finish.
- Track when API call for Figures and Citations finish, then configure completion percentage.

This resolves the unwanted effect of the component loading in and then disappearing right away when loading the page of a paper that has already been completed.