### PR TITLE
Pass Paper's Metadata to Backend

### DIFF
--- a/components/Paper/PaperUploadInfo.js
+++ b/components/Paper/PaperUploadInfo.js
@@ -56,11 +56,8 @@ class PaperUploadInfo extends React.Component {
         author: {
           self_author: false,
         },
-        type: {
-          journal: false,
-          conference: false,
-          other: false,
-        },
+        raw_authors: [],
+        type: "",
         hubs: [],
       },
       error: {
@@ -135,8 +132,7 @@ class PaperUploadInfo extends React.Component {
   prefillPaperInfo = () => {
     let { uploadedPaper } = this.props.paper;
     let form = { ...this.state.form };
-    let { DOI, url, title, abstract, issued } = uploadedPaper;
-
+    let { DOI, url, title, abstract, issued, type, author } = uploadedPaper;
     if (title || this.props.paperTitle) {
       form.paper_title = this.props.paperTitle
         ? this.props.paperTitle
@@ -157,6 +153,18 @@ class PaperUploadInfo extends React.Component {
       form.published.month = this.handleFormMonth(date);
       form.published.day = this.handleFormDay(date);
     }
+    if (author && author.length) {
+      form.raw_authors = author.map((a, i) => {
+        return {
+          first_name: a.given ? a.given : "",
+          lasat_name: a.family ? a.family : "",
+        };
+      });
+    }
+    if (type) {
+      form.type = type;
+    }
+
     this.setState({ form: form }, () => {
       this.props.messageActions.showMessage({ show: false });
       this.checkFormProgress();

--- a/redux/paper/shims.js
+++ b/redux/paper/shims.js
@@ -41,11 +41,17 @@ export const paperPost = ({
   tagline,
   abstract,
   paper_title,
+  raw_authors,
 }) => {
   let formData = new FormData();
   authors &&
     authors.forEach((author) => {
-      return formData.append("authors", author);
+      return formData.append("authors", JSON.stringify(author));
+    });
+
+  raw_authors &&
+    raw_authors.forEach((author) => {
+      return formData.append("raw_authors", JSON.stringify(author));
     });
   hubs &&
     hubs.forEach((hub) => {


### PR DESCRIPTION
**Feature**

1. Allow raw_authors and publish_date retrieved from Manubot (link uploads) to be saved.

![Experiments_in_Extractive_Summarization__Integer_Linear_Programming__Term_Sentence_Scoring__and_Title-driven_Models](https://user-images.githubusercontent.com/36824145/90285691-3906e500-de29-11ea-954e-0c2cd95201bb.png)
