### PR TITLE
Paper Page Hub Tags

### DIFF
--- a/components/PaperPageCard.js
+++ b/components/PaperPageCard.js
@@ -538,6 +538,7 @@ class PaperPageCard extends React.Component {
                   gray={false}
                   key={`hub_tag_index_${index}`}
                   overrideStyle={this.state.showAllHubs && styles.tagStyle}
+                  last={last}
                 />
               );
             }


### PR DESCRIPTION
**Feature**

1. Closes #545, Mirror top section of paper to the homepage card.

<img width="1392" alt="Science_is_Shaped_by_Wikipedia__Evidence_From_a_Randomized_Control_Trial_" src="https://user-images.githubusercontent.com/36824145/91234853-1312f780-e6e9-11ea-89d9-c413380084e2.png">

![Magma_ocean_evolution_of_the_TRAPPIST-1_planets](https://user-images.githubusercontent.com/36824145/91234903-3047c600-e6e9-11ea-8f58-a0431587430e.png)
