### PR TITLE
Author Leaderboard

### DIFF
--- a/pages/leaderboard/LeaderboardPage.js
+++ b/pages/leaderboard/LeaderboardPage.js
@@ -268,7 +268,6 @@ class Index extends React.Component {
       filterOptions.filter((filter) => {
         return filter.value === scope.split("-").join("_");
       })[0];
-
     this.setState(
       {
         type,
@@ -307,9 +306,11 @@ class Index extends React.Component {
         break;
       case "authors":
         type = "Authors";
+        break;
       default:
         return null;
     }
+
     return `Top ${type} ${this.state.by.value === 0 ? "on" : "in"} ${
       this.state.by.label
     } ${this.state.filterBy.label}`;


### PR DESCRIPTION
**Features**

1. Allow users to view top authors (leaderboard) on Researchhub.

2. Add Empty State to Leaderboard tabs when query returns empty.

**Dependent on Backend branch `leo/author`**

![https___staging-web_researchhub_com_leaderboard_authors_researchhub_all-time](https://user-images.githubusercontent.com/36824145/91496528-24870b80-e871-11ea-8086-3664b4d4c4e6.png)

![https___staging-web_researchhub_com_leaderboard_authors_adult-and-continuing-education-1_all-time](https://user-images.githubusercontent.com/36824145/91496547-29e45600-e871-11ea-8d0c-a1de074dbce7.png)
