### PR TITLE
ensured paper data exists before checkUserVote update

### DIFF
--- a/pages/paper/[paperId]/[paperName]/index.js
+++ b/pages/paper/[paperId]/[paperName]/index.js
@@ -235,7 +235,9 @@ const Paper = (props) => {
   }, [paperId]);
 
   useEffect(() => {
-    checkUserVote();
+    if (Object.keys(paper).length !== 0) {
+      checkUserVote();
+    }
   }, [props.auth.isLoggedIn]);
 
   useEffect(() => {


### PR DESCRIPTION
When this useEffect is triggered during page redirects (client-side) the `paper` state var is `{}` but that's what `checkUserVote()` also sees, so this check will ensure we already have paper data before making the update in `checkUserVote()`. 

https://app.zenhub.com/workspaces/researchhub-development-5e44b40cd52495f9cea7e52a/issues/researchhub/researchhub-backend/602