### PR TITLE
PaperDraft - Allow Keyboard Shortcuts that does not affect DraftState

### DIFF
--- a/components/PaperDraft/PaperDraft.js
+++ b/components/PaperDraft/PaperDraft.js
@@ -171,7 +171,7 @@ class PaperDraft extends React.Component {
             />
           </div>
           <PaperDraftEventCaptureWrap
-            shouldAllowKeyEvents={isLoggedIn}
+            shouldAllowKeyEvents={true}
             shouldAllowMouseEvents={isLoggedIn}
           >
             <div


### PR DESCRIPTION
 - Allow Keyboard Shortcuts that does not affect DraftState
 - includes copy & paste and page-refresh

