### PR TITLE
LargeList, LargeListItem components with revisions and types

### DIFF
--- a/components/Form/LargeList.tsx
+++ b/components/Form/LargeList.tsx
@@ -1,15 +1,22 @@
-import React, { useState } from "react";
+import React, { ReactChildren, useState } from "react";
 import { StyleSheet, css } from "aphrodite";
 
 // Components
 import LargeListItem from "~/components/Form/LargeListItem";
+
+type LargeListProps = {
+  selectMany: boolean;
+  customListStyle: StyleSheet;
+  onChange?: Function;
+  children: ReactChildren;
+};
 
 export default function LargeList({
   selectMany,
   customListStyle,
   onChange,
   children,
-}) {
+}: LargeListProps) {
   let [isActives, setIsActives] = useState(children.map(() => false));
 
   const renderListItem = (item, index) => {

--- a/components/Form/LargeListItem.tsx
+++ b/components/Form/LargeListItem.tsx
@@ -1,8 +1,16 @@
-import React, { useState } from "react";
+import React, { ReactChildren, useState } from "react";
 import { StyleSheet, css } from "aphrodite";
 
 // Components
 import CheckBox from "~/components/Form/CheckBox";
+
+type LargeListItemProps = {
+  checkboxSquare: boolean;
+  active: boolean;
+  id?: string;
+  onChange?: Function;
+  children: ReactChildren;
+};
 
 export default function LargeListItem({
   checkboxSquare,
@@ -10,7 +18,7 @@ export default function LargeListItem({
   id,
   onChange,
   children,
-}) {
+}: LargeListItemProps) {
   return (
     <div className={css(styles.largeListItem)}>
       <div className={css(styles.checkboxAligner)}>


### PR DESCRIPTION
Revised requested changes from https://github.com/ResearchHub/researchhub-web-internal/pull/785
LargeList/LargeListItem is the selectable list of gray, rectangular, containers underneath "Select your post type".
![image](https://user-images.githubusercontent.com/22692190/118739619-c46d3680-b7fe-11eb-943a-975f7573490a.png)
