### PR TITLE
Added PDF viewer when clicking paper image preview in feed

### DIFF
--- a/components/Hubs/PaperEntryCard.js
+++ b/components/Hubs/PaperEntryCard.js
@@ -3,9 +3,7 @@ import Link from "next/link";
 import Router from "next/router";
 import { connect, useStore } from "react-redux";
 import { StyleSheet, css } from "aphrodite";
-import Carousel from "nuka-carousel";
 import Ripples from "react-ripples";
-import FsLightbox from "fslightbox-react";
 import ReactTooltip from "react-tooltip";
 
 // Components
@@ -13,6 +11,7 @@ import VoteWidget from "../VoteWidget";
 import HubTag from "./HubTag";
 import HubDropDown from "./HubDropDown";
 import PaperJournalTag from "../Paper/PaperJournalTag";
+import PaperPDFModal from "~/components/Modals/PaperPDFModal";
 
 // Utility
 import {
@@ -30,6 +29,7 @@ import { PaperActions } from "~/redux/paper";
 import API from "~/config/api";
 import { Helpers } from "@quantfive/js-web-config";
 import AuthorAvatar from "../AuthorAvatar";
+import { ModalActions } from "~/redux/modals";
 
 const PaperEntryCard = (props) => {
   const {
@@ -75,8 +75,14 @@ const PaperEntryCard = (props) => {
 
   let vote_type = 0;
   let selected = setVoteSelected(paper.user_vote);
-  const [lightbox, toggleLightbox] = useState(false);
-  const [slideIndex, setSlideIndex] = useState(1);
+
+  /**
+   * Whether or not THIS PaperPDFModal is open.
+   * There may be many PaperPDFModal components on the page, but
+   * modals.openPaperPDFModal is only a single boolean. So all cards
+   * must only render their PaperPDFModal component if requested */
+  const [isPreviewing, setIsPreviewing] = useState(false);
+
   const [isOpen, setIsOpen] = useState(false); // Hub dropdown
   const [previews] = useState(
     configurePreview([
@@ -278,6 +284,13 @@ const PaperEntryCard = (props) => {
     );
   };
 
+  const openPaperPDFModal = (e) => {
+    e && e.preventDefault();
+    e && e.stopPropagation();
+    setIsPreviewing(true);
+    props.openPaperPDFModal(true);
+  };
+
   const renderContent = () => {
     if (bullet_points && bullet_points.length > 0) {
       return (
@@ -317,36 +330,20 @@ const PaperEntryCard = (props) => {
             e.stopPropagation();
           }}
         >
-          <div
-            className={css(styles.preview)}
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              toggleLightbox(!lightbox);
-            }}
-          >
-            <Carousel
-              afterSlide={(slideIndex) => setSlideIndex(slideIndex + 1)}
-              renderBottomCenterControls={null}
-              renderCenterLeftControls={null}
-              renderCenterRightControls={null}
-              wrapAround={true}
-              enableKeyboardControls={true}
-            >
-              {previews.map((preview, i) => {
-                if (preview && i == 0) {
-                  return (
-                    <img
-                      src={preview.file}
-                      className={css(carousel.image)}
-                      key={`preview_${preview.file}`}
-                      alt={`Paper Preview Page ${i + 1}`}
-                      loading="lazy"
-                    />
-                  );
-                }
-              })}
-            </Carousel>
+          {isPreviewing && (
+            <PaperPDFModal
+              paper={paper}
+              onClose={() => setIsPreviewing(false)}
+            />
+          )}
+          <div className={css(styles.preview)}>
+            <img
+              src={previews[0].file}
+              className={css(carousel.image)}
+              key={`preview_${previews[0].file}`}
+              alt={`Paper Preview Page 1`}
+              onClick={openPaperPDFModal}
+            />
           </div>
         </div>
       );
@@ -587,16 +584,6 @@ const PaperEntryCard = (props) => {
       onClick={navigateToPage}
     >
       <ReactTooltip />
-      {figures.length > 0 && (
-        <div onClick={(e) => e.stopPropagation()}>
-          <FsLightbox
-            toggler={lightbox}
-            type="image"
-            sources={[...figures]}
-            slide={slideIndex}
-          />
-        </div>
-      )}
       {desktopOnly(renderVoteWidget())}
       <div className={css(styles.container)}>
         <div className={css(styles.rowContainer)}>
@@ -1101,6 +1088,7 @@ const mapDispatchToProps = {
   postUpvote: PaperActions.postUpvote,
   postDownvote: PaperActions.postDownvote,
   updatePaperState: PaperActions.updatePaperState,
+  openPaperPDFModal: ModalActions.openPaperPDFModal,
 };
 
 export default connect(

--- a/components/Modals/PaperPDFModal.js
+++ b/components/Modals/PaperPDFModal.js
@@ -12,7 +12,7 @@ import { ModalActions } from "~/redux/modals";
 import { convertHttpToHttps } from "~/config/utils";
 
 const PaperPDFModal = (props) => {
-  const { paper, modals, openPaperPDFModal } = props;
+  const { paper, modals, openPaperPDFModal, onClose } = props;
   const { file, pdf_url } = paper;
 
   function closeModal() {
@@ -23,6 +23,13 @@ const PaperPDFModal = (props) => {
     if (process.browser) {
       document.body.style.overflow = "scroll";
     }
+
+    /**
+     * it is helpful to have onClose callback since there
+     * may be many PaperPDFModal's rendered, but modals.openPaperPDFModal is only a single boolean
+     * and cannot specify which one is open */
+    onClose && onClose();
+
     return openPaperPDFModal && openPaperPDFModal(false);
   }
 


### PR DESCRIPTION
When clicking on the Paper preview image on a card: 
![image](https://user-images.githubusercontent.com/22692190/119038260-c0a8f380-b967-11eb-8179-cb36cefd6db0.png)
The PDF viewer opens instead of FsLightBox.
![image](https://user-images.githubusercontent.com/22692190/119038343-de765880-b967-11eb-9e6a-9492310e6776.png)
