### PR TITLE
[Paper Top Card][UI][1/1] Readded Support Paper Button

### DIFF
--- a/components/PaperPageCard.js
+++ b/components/PaperPageCard.js
@@ -336,6 +336,19 @@ class PaperPageCard extends React.Component {
         ),
       },
       {
+        active: !isSubmitter,
+        button: (
+          <span data-tip={"Flag Paper"}>
+            <FlagButton
+              paperId={paper.id}
+              flagged={flagged}
+              setFlag={setFlag}
+              style={styles.actionIcon}
+            />
+          </span>
+        ),
+      },
+      {
         active: isModerator || isSubmitter,
         button: (
           <span
@@ -349,19 +362,6 @@ class PaperPageCard extends React.Component {
               icon={paper.is_removed ? icons.plus : icons.minus}
               onAction={paper.is_removed ? this.restorePaper : this.removePaper}
               iconStyle={styles.moderatorIcon}
-            />
-          </span>
-        ),
-      },
-      {
-        active: !isModerator && !isSubmitter,
-        button: (
-          <span data-tip={"Flag Paper"}>
-            <FlagButton
-              paperId={paper.id}
-              flagged={flagged}
-              setFlag={setFlag}
-              style={styles.actionIcon}
             />
           </span>
         ),


### PR DESCRIPTION
- Readded Support Paper Button on the left column underneath the upvote/downvote widgets. 
- Note: Divider was also re-added to make the singular appearance of the support paper button less awkward
![image](https://user-images.githubusercontent.com/22692190/119903195-36c7d000-befd-11eb-8b5f-4f5739c11901.png)
