### PR TITLE
Bug Fix: Clicking "Save & Submit" in Onboarding crashes

### DIFF
--- a/components/Onboard/OnboardForm.js
+++ b/components/Onboard/OnboardForm.js
@@ -203,7 +203,7 @@ class OnboardForm extends React.Component {
       headline: this.state.headline,
     };
 
-    return fetch(
+    fetch(
       API.AUTHOR({ authorId: this.props.author.id }),
       API.PATCH_CONFIG(params)
     )
@@ -658,11 +658,11 @@ const mapDispatchToProps = {
   showMessage: MessageActions.showMessage,
 };
 
-const A = connect(
+const WrappedComponent = connect(
   mapStateToProps,
   mapDispatchToProps
 )(OnboardForm);
 
-const B = React.forwardRef((props, ref) => <A {...props} submitBtnRef={ref} />);
-
-export default B;
+export default React.forwardRef((props, ref) => (
+  <WrappedComponent {...props} submitBtnRef={ref} />
+));

--- a/pages/user/[authorId]/onboard/index.js
+++ b/pages/user/[authorId]/onboard/index.js
@@ -203,7 +203,12 @@ const Index = (props) => {
   };
 
   const saveUserInformation = () => {
-    onboardingFormBtnRef.current.click();
+    onboardingFormBtnRef.current
+      ? onboardingFormBtnRef.current.click()
+      : console.warn(
+          "No ref provided to OnboardForm. Profile changes not saved."
+        );
+
     navigateHome();
   };
 


### PR DESCRIPTION
**What?**

- Click "Save & Submit" in the final step of onboarding results in exception due to a `ref` not being forwarded properly to the `OnboardForm` component

**The Fix**
- Forward ref properly 
- Fix will work without ref being forwarded but instead, will log a console warning message


![image](https://user-images.githubusercontent.com/802819/121393702-9d49e680-c91e-11eb-9ead-eaf3f45689c0.png)
