### PR TITLE
[Comment Ban Fix][UI][1/1] Fixed error message on banning user via their comment

### DIFF
--- a/components/Moderator/ModeratorDeleteButton.js
+++ b/components/Moderator/ModeratorDeleteButton.js
@@ -217,13 +217,14 @@ const ModeratorDeleteButton = (props) => {
       .then(Helpers.checkStatus)
       .then(Helpers.parseJSON)
       .then((res) => {
-        setIsSuspended(true);
+        setIsSuspended && setIsSuspended(true);
         if (auth.user.author_profile.id === authorId) {
-          updateUser({
-            ...auth.user,
-            is_suspended: true,
-            probable_spammer: true,
-          });
+          updateUser &&
+            updateUser({
+              ...auth.user,
+              is_suspended: true,
+              probable_spammer: true,
+            });
         }
         showSucessMessage("User Successfully Removed.");
         props.onRemove &&

--- a/components/Threads/DiscussionEntry.js
+++ b/components/Threads/DiscussionEntry.js
@@ -242,12 +242,13 @@ class DiscussionEntry extends React.Component {
 
   onRemove = ({ paperID, threadID, commentID, replyID }) => {
     this.setState({ removed: true });
-    this.props.onRemoveSuccess({
-      commentID,
-      paperID,
-      replyID,
-      threadID,
-    });
+    this.props.onRemoveSuccess &&
+      this.props.onRemoveSuccess({
+        commentID,
+        paperID,
+        replyID,
+        threadID,
+      });
   };
 
   renderComments = () => {


### PR DESCRIPTION
Although banning a user via the dropdown on their commnent successfully bans them, an error message saying "Something went wrong" would appear. This was fixed, the issue being that two undefined functions were being called (setIsSuspended, onRemoveSuccess)