### PR TITLE
Change GET_HUB_PAPERS to fetchUnifiedDocFeed

### DIFF
--- a/components/Hubs/HubPage.js
+++ b/components/Hubs/HubPage.js
@@ -36,7 +36,7 @@ import { Helpers } from "@quantfive/js-web-config";
 import colors from "~/config/themes/colors";
 import {
   checkUserVotesOnPapers,
-  fetchPaperFeed,
+  fetchUnifiedDocFeed,
   fetchURL,
 } from "~/config/fetch";
 import { getFragmentParameterByName } from "~/config/utils";
@@ -277,7 +277,7 @@ class HubPage extends React.Component {
       PARAMS.ordering = "hot";
     }
 
-    fetchPaperFeed(PARAMS)
+    fetchUnifiedDocFeed(PARAMS)
       .then((res) => {
         const { count, next, results } = res;
         const papers = results.data;

--- a/pages/all/index.js
+++ b/pages/all/index.js
@@ -44,7 +44,7 @@ Index.getInitialProps = async (ctx) => {
   };
 
   try {
-    const initialFeed = await fetchPaperFeed(PARAMS);
+    const initialFeed = await fetchUnifiedDocFeed(PARAMS);
 
     return {
       ...defaultProps,

--- a/pages/hubs/[slug]/[filter]/[scope]/index.js
+++ b/pages/hubs/[slug]/[filter]/[scope]/index.js
@@ -15,6 +15,7 @@ import {
   calculateScopeFromSlug,
 } from "~/config/utils/routing";
 import { filterOptions, scopeOptions } from "~/config/utils/options";
+import { fetchUnifiedDocFeed } from "~/config/fetch";
 
 class Index extends React.Component {
   static async getInitialProps(ctx) {
@@ -45,9 +46,7 @@ class Index extends React.Component {
       }
 
       const [initialFeed, leaderboardFeed, initialHubList] = await Promise.all([
-        fetch(API.GET_HUB_PAPERS(PARAMS), API.GET_CONFIG()).then((res) =>
-          res.json()
-        ),
+        fetchUnifiedDocFeed(PARAMS).then((res) => res.json()),
         fetch(
           API.LEADERBOARD({ limit: 10, page: 1, hubId: currentHub.id }), // Leaderboard
           API.GET_CONFIG()

--- a/pages/hubs/[slug]/[filter]/index.js
+++ b/pages/hubs/[slug]/[filter]/index.js
@@ -12,6 +12,7 @@ import { toTitleCase } from "~/config/utils";
 import { getInitialScope } from "~/config/utils/dates";
 import { slugToFilterQuery } from "~/config/utils/routing";
 import { filterOptions } from "~/config/utils/options";
+import { fetchUnifiedDocFeed } from "~/config/fetch";
 
 class Index extends React.Component {
   static async getInitialProps(ctx) {
@@ -39,9 +40,7 @@ class Index extends React.Component {
       }
 
       const [initialFeed, leaderboardFeed, initialHubList] = await Promise.all([
-        fetch(API.GET_HUB_PAPERS(PARAMS), API.GET_CONFIG()).then((res) =>
-          res.json()
-        ),
+        fetchUnifiedDocFeed(PARAMS).then((res) => res.json()),
         fetch(
           API.LEADERBOARD({ limit: 10, page: 1, hubId: currentHub.id }), // Leaderboard
           API.GET_CONFIG()

--- a/pages/hubs/[slug]/index.js
+++ b/pages/hubs/[slug]/index.js
@@ -11,6 +11,7 @@ import API from "~/config/api";
 import { Helpers } from "@quantfive/js-web-config";
 import { toTitleCase } from "~/config/utils";
 import { getInitialScope } from "~/config/utils/dates";
+import { fetchUnifiedDocFeed } from "~/config/fetch";
 
 const isServer = () => typeof window === "undefined";
 
@@ -43,15 +44,12 @@ class Index extends React.Component {
 
     try {
       const [initialFeed, leaderboardFeed, initialHubList] = await Promise.all([
-        fetch(
-          API.GET_HUB_PAPERS({
-            // Initial Feed
-            hubId: currentHub.id,
-            ordering: "hot",
-            timePeriod: getInitialScope(),
-          }),
-          API.GET_CONFIG()
-        ).then((res) => res.json()),
+        fetchUnifiedDocFeed({
+          // Initial Feed
+          hubId: currentHub.id,
+          ordering: "hot",
+          timePeriod: getInitialScope(),
+        }).then((res) => res.json()),
         fetch(
           API.LEADERBOARD({ limit: 10, page: 1, hubId: currentHub.id }), // Leaderboard
           API.GET_CONFIG()

--- a/pages/index.js
+++ b/pages/index.js
@@ -5,6 +5,8 @@ import { getInitialScope } from "~/config/utils/dates";
 import { Helpers } from "@quantfive/js-web-config";
 import nookies from "nookies";
 import { AUTH_TOKEN } from "../config/constants";
+import { fetchUnifiedDocFeed } from "../config/fetch";
+
 const isServer = () => typeof window === "undefined";
 
 const Index = (props) => {
@@ -12,21 +14,16 @@ const Index = (props) => {
 };
 
 const getHubPapers = (page, authToken) => {
-  return fetch(
-    API.GET_HUB_PAPERS({
-      hubId: 0,
-      ordering: "hot",
-      timePeriod: getInitialScope(),
-      subscribedHubs: true,
-      page,
-    }),
-    API.GET_CONFIG(authToken)
-  )
-    .then(Helpers.checkStatus)
-    .then(Helpers.parseJSON)
-    .then((res) => {
-      return res;
-    });
+  let params = {
+    hubId: 0,
+    ordering: "hot",
+    timePeriod: getInitialScope(),
+    subscribedHubs: true,
+    page,
+  };
+  return fetchUnifiedDocFeed(params).then((res) => {
+    return res;
+  });
 };
 
 Index.getInitialProps = async (ctx) => {


### PR DESCRIPTION
Legacy code that wasn't removed. GET_HUB_PAPERS was slowing down the site tremendously.

There still needs to be work done to cleanup double fetch calls on SSR, and other things related, but for now this massively speeds up the site.