### PR TITLE
Search Hotfix: Rendering Horizontal Bar only after pageWidth is determined

### DIFF
--- a/components/HorizontalTabBar.js
+++ b/components/HorizontalTabBar.js
@@ -47,22 +47,24 @@ const HorizontalTabBar = ({
 
   return (
     <div className={css(styles.container, containerStyle)}>
-      <ScrollMenu
-        arrowLeft={
-          pageWidth <= showArrowsOnWidth ? (
-            <NavigationArrow icon={icons.chevronLeft} direction={"left"} />
-          ) : null
-        }
-        arrowRight={
-          pageWidth <= showArrowsOnWidth ? (
-            <NavigationArrow icon={icons.chevronRight} direction={"right"} />
-          ) : null
-        }
-        data={tabsHtml}
-        menuStyle={styles.tabContainer}
-        alignCenter={alignCenter}
-        dragging={dragging}
-      />
+      {pageWidth > 0 && (
+        <ScrollMenu
+          arrowLeft={
+            pageWidth <= showArrowsOnWidth ? (
+              <NavigationArrow icon={icons.chevronLeft} direction={"left"} />
+            ) : null
+          }
+          arrowRight={
+            pageWidth <= showArrowsOnWidth ? (
+              <NavigationArrow icon={icons.chevronRight} direction={"right"} />
+            ) : null
+          }
+          data={tabsHtml}
+          menuStyle={styles.tabContainer}
+          alignCenter={alignCenter}
+          dragging={dragging}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
**What?**
- Horizontal scroll bar is buggy and its state is determined on the first render. If pageWidth is 0, then it will be disabled.