### PR TITLE
Hotfix: Papers in search missing score

### DIFF
--- a/components/Hubs/PaperEntryCard.js
+++ b/components/Hubs/PaperEntryCard.js
@@ -78,6 +78,7 @@ const PaperEntryCard = (props) => {
 
   let vote_type = 0;
   let selected = setVoteSelected(paper.user_vote);
+  boost_amount = boost_amount || 0;
 
   /**
    * Whether or not THIS PaperPDFModal is open.


### PR DESCRIPTION
This is a temporary fix. A more robust fix will be [done as part of this ticket](https://www.notion.so/researchhub/74df45c49b894f09b92694a6bf4f9b8e?v=5f243f290f6b442f97d977f720a393ec&p=364c773677114227859449237898e80f) .