### PR TITLE
Fixed a bug with removing papers/posts as a non-moderator

### DIFF
--- a/components/Paper/PaperBanner.js
+++ b/components/Paper/PaperBanner.js
@@ -47,16 +47,9 @@ const PaperBanner = ({
       }
     }
     const isRemoved = postType === "post" ? post.is_removed : paper.is_removed;
-    const isRemovedByUser = paper && paper.is_removed_by_user;
 
     if (isRemoved) {
       setType("removed");
-      setShowBanner(true);
-      return;
-    }
-
-    if (isRemovedByUser) {
-      setType("removedBbyUser");
       setShowBanner(true);
       return;
     }
@@ -76,8 +69,8 @@ const PaperBanner = ({
               {renderIcon(true)}
               {post ? "Post" : "Paper"} Removed
             </h3>
-            This {post ? "post" : "paper"} has been removed for having poor
-            quality content and not adhering to guidelines.
+            This {post ? "post" : "paper"} has been removed by the submitter or
+            for having poor quality content and not adhering to guidelines.
             <br />
             Please visit our{" "}
             <a
@@ -89,16 +82,6 @@ const PaperBanner = ({
               {post ? "Post" : "Paper"} Submission Guidelines
             </a>{" "}
             to review our standard.
-          </div>
-        );
-      case "removedByUser":
-        return (
-          <div className={css(styles.removedMessage)}>
-            <h3 className={css(styles.header)}>
-              {renderIcon(true)}
-              Paper Removed
-            </h3>
-            This paper has been removed from ResearchHub by the submitter.
           </div>
         );
       default:

--- a/components/PaperPageCard.js
+++ b/components/PaperPageCard.js
@@ -100,12 +100,8 @@ class PaperPageCard extends React.Component {
       restorePaper,
     } = this.props;
     let params = {};
-    if (isModerator) {
+    if (isModerator || isSubmitter) {
       params.is_removed = false;
-    }
-
-    if (isSubmitter) {
-      params.is_removed_by_user = false;
     }
 
     return fetch(API.PAPER({ paperId }), API.PATCH_CONFIG(params))
@@ -128,12 +124,8 @@ class PaperPageCard extends React.Component {
       removePaper,
     } = this.props;
     let params = {};
-    if (isModerator) {
+    if (isModerator || isSubmitter) {
       params.is_removed = true;
-    }
-
-    if (isSubmitter) {
-      params.is_removed_by_user = true;
     }
 
     return fetch(API.PAPER({ paperId }), API.PATCH_CONFIG(params))

--- a/components/PostPageCard.js
+++ b/components/PostPageCard.js
@@ -90,7 +90,7 @@ class PostPageCard extends React.Component {
     return url;
   };
 
-  restorePaper = () => {
+  restoreThisPost = () => {
     let {
       setMessage,
       showMessage,
@@ -100,12 +100,8 @@ class PostPageCard extends React.Component {
       restorePost,
     } = this.props;
     let params = {};
-    if (isModerator) {
+    if (isModerator || isSubmitter) {
       params.is_removed = false;
-    }
-
-    if (isSubmitter) {
-      params.is_removed_by_user = false;
     }
 
     return fetch(
@@ -121,10 +117,17 @@ class PostPageCard extends React.Component {
       });
   };
 
-  removePaper = () => {
-    let { setMessage, showMessage, isModerator, post, removePost } = this.props;
+  removeThisPost = () => {
+    let {
+      setMessage,
+      showMessage,
+      isModerator,
+      isSubmitter,
+      post,
+      removePost,
+    } = this.props;
     let params = {};
-    if (isModerator) {
+    if (isModerator || isSubmitter) {
       params.is_removed = true;
     }
 
@@ -376,7 +379,9 @@ class PostPageCard extends React.Component {
               paperId={post.id}
               restore={post.is_removed}
               icon={post.is_removed ? icons.plus : icons.minus}
-              onAction={post.is_removed ? this.restorePaper : this.removePaper}
+              onAction={
+                post.is_removed ? this.restoreThisPost : this.removeThisPost
+              }
               containerStyle={styles.moderatorContainer}
               iconStyle={styles.moderatorIcon}
             />


### PR DESCRIPTION
**What?**
There was a bug where non-moderators would not be able to remove their own papers/posts.
This PR removes references to `is_removed_by_user` for papers and only uses `is_removed` now to be consistent with posts/hypotheses.