### PR TITLE
Fixed a bug with names not showing up in AuthorCard

### DIFF
--- a/components/Paper/SideColumn/AuthorCard.js
+++ b/components/Paper/SideColumn/AuthorCard.js
@@ -47,9 +47,11 @@ const AuthorCard = (props) => {
           ) : (
             <span className={css(styles.userIcon)}>{icons.user}</span>
           )}
-          {authorUserID ? null : (
-            <AccruedRSC name={name} accruedRSC={accruedRSC} />
-          )}
+          {
+            authorUserID
+              ? <div className={css(styles.name) + " clamp1"}>{name}</div>
+              : <AccruedRSC name={name} accruedRSC={accruedRSC} />
+          }
         </a>
       </Link>
     );

--- a/components/Paper/SideColumn/ColumnAuthors.js
+++ b/components/Paper/SideColumn/ColumnAuthors.js
@@ -148,7 +148,7 @@ class ColumnAuthors extends Component {
         <div>
           <div className={css(styles.paperAuthorListContainer)}>
             <SideColumnTitle
-              title={`Author Detail${hasManyAuthors ? "s" : ""}`}
+              title={`Author${hasManyAuthors ? "s" : ""}`}
               overrideStyles={styles.title}
             />
             {shouldDisplayClaimCard && (


### PR DESCRIPTION
This is currently affecting prod:
<img width="1069" alt="Screen Shot 2021-08-27 at 6 35 51 PM" src="https://user-images.githubusercontent.com/22990196/131200540-548951a2-475c-482f-a8b0-f46fa5308b1c.png">