### PR TITLE
[HOTFIX] Incorrect redirect when slug is missing

### DIFF
--- a/pages/paper/[paperId]/[paperName]/index.js
+++ b/pages/paper/[paperId]/[paperName]/index.js
@@ -641,7 +641,7 @@ export async function getStaticProps(ctx) {
     if (paper.slug && paper.slug !== slugFromQuery) {
       return {
         redirect: {
-          destination: paper.slug,
+          destination: `/paper/${paperId}/${paper.slug}`,
           permanent: true,
         },
       };


### PR DESCRIPTION
### What?
- [x] Redirect to absolute route (instead of relative) when `slug` is missing from paper