### PR TITLE
fixed button width in mobile hamburger menu

### DIFF
--- a/components/Form/Button.js
+++ b/components/Form/Button.js
@@ -121,7 +121,7 @@ const styles = StyleSheet.create({
     ":hover": {
       backgroundColor: "#3E43E8",
     },
-    "@media only screen and (max-width: 767px)": {
+    "@media only screen and (max-width: 415px)": {
       width: "unset",
       height: "unset",
       minHeight: 45,
@@ -161,7 +161,7 @@ const styles = StyleSheet.create({
     height: 30,
     width: "auto",
     paddingLeft: 10,
-    paddingRight: 10,    
+    paddingRight: 10,
   },
   small: {
     width: 126,


### PR DESCRIPTION
# Before
<img width="431" alt="Screen Shot 2021-12-06 at 3 10 02 PM" src="https://user-images.githubusercontent.com/22990196/144930875-703ec164-84a3-45fe-9b05-277b692c6648.png">

# After
<img width="431" alt="Screen Shot 2021-12-06 at 3 10 25 PM" src="https://user-images.githubusercontent.com/22990196/144930888-5328ca29-8dfd-4b3e-ac61-a3b85c482a20.png">
