### PR TITLE
Author Avatar no longer propagates clicks

### DIFF
--- a/components/AuthorAvatar.js
+++ b/components/AuthorAvatar.js
@@ -117,6 +117,9 @@ const AuthorAvatar = (props) => {
             href={`/user/${authorId}/overview`}
             className={css(styles.atag)}
             rel="noreferrer noopener"
+            onClick={(e) => {
+              e.stopPropagation();
+            }}
           >
             {renderAvatar()}
           </a>


### PR DESCRIPTION
Fixes an issue where if you click the author avatar, the paper card also gets triggered as a click

https://www.loom.com/share/ecdb5a42be0742668ff0c1164a13da18