### PR TITLE
Removing formatting quill btn, darker quote color in editor

### DIFF
--- a/components/TextEditor/QuillTextEditor.js
+++ b/components/TextEditor/QuillTextEditor.js
@@ -330,6 +330,9 @@ class Editor extends Component {
               <button className="ql-image" />
               <button className="ql-video"></button>
             </span>
+            <span class="ql-formats">
+              <button class="ql-clean"></button>
+            </span>
           </Fragment>
         )}
       </div>

--- a/components/TextEditor/stylesheets/QuillTextEditor.css
+++ b/components/TextEditor/stylesheets/QuillTextEditor.css
@@ -89,7 +89,7 @@
 }
 
 .ql-editor > blockquote {
-  color: #aaaaaa;
+  color: #656565;
   font-style: italic;
 }
 


### PR DESCRIPTION
- Remove formatting button in Quill
- Darken the blockquote text color