### PR TITLE
Fix issue with slug being wrong in editor of in profile page

### DIFF
--- a/components/PaperPageCard.js
+++ b/components/PaperPageCard.js
@@ -303,7 +303,6 @@ class PaperPageCard extends Component {
       setFlag,
     } = this.props;
 
-    console.log(paper.uploaded_by);
     const { paper_title, title, uploaded_by } = paper || {};
     const uploadedById = uploaded_by && paper.uploaded_by.id;
     const isUploaderSuspended =

--- a/pages/hubs/[slug]/index.js
+++ b/pages/hubs/[slug]/index.js
@@ -33,7 +33,11 @@ class Index extends Component {
       .then((body) => body.results[0]);
 
     if (!currentHub) {
-      throw 404;
+      if (res) {
+        res.statusCode = 404;
+      }
+
+      return { error: true };
     }
 
     try {
@@ -104,7 +108,7 @@ class Index extends Component {
   }
 
   componentDidMount() {
-    if (!this.props.initialProps.initialFeed) {
+    if (!this.props.initialProps?.initialFeed) {
       this.fetchHubInfo(this.state.slug);
     }
   }

--- a/pages/user/[authorId]/[tabName]/index.js
+++ b/pages/user/[authorId]/[tabName]/index.js
@@ -777,15 +777,11 @@ function AuthorPage(props) {
   );
 
   const authorIsEditorOf = (author?.is_hub_editor_of ?? []).map((hub, i) => {
-    const { name } = hub;
-    const sluggedName = buildSlug(hub.name ?? "");
+    const { name, slug } = hub;
+    const sluggedName = buildSlug(hub.slug ?? "");
     return (
-      <Link href={"/hubs/[slug]"} as={`/hubs/${sluggedName}`}>
-        <a
-          className={css(styles.hubLinkTag)}
-          href={`/hubs/${sluggedName}`}
-          target="_blank"
-        >
+      <Link href={"/hubs/[slug]"} as={`/hubs/${slug}`}>
+        <a className={css(styles.hubLinkTag)}>
           {i > 0 && ", "}
           {name}
         </a>


### PR DESCRIPTION
Users were seeing a 500 on hub pages. 

Fixed the issue, so they should be seeing a 404 instead, but also they shouldn't have seen a 404 but instead should have seen the correct hub page

<img width="401" alt="Screen Shot 2022-01-03 at 11 27 36 AM" src="https://user-images.githubusercontent.com/2453737/147954961-339a937f-3e2a-4b9c-893c-9b9aef5e6b61.png">
correct page.

