### PR TITLE
Sorting replies by created_date

### DIFF
--- a/components/Threads/CommentEntry.js
+++ b/components/Threads/CommentEntry.js
@@ -498,6 +498,9 @@ class CommentEntry extends Component {
       this.state.replies.length < 1
         ? this.props.comment.replies
         : this.state.replies;
+    replies = replies.sort(
+      (a, b) => new Date(a.created_date) - new Date(b.created_date)
+    );
     return replies.map((reply, i) => {
       return (
         <ReplyEntry


### PR DESCRIPTION
Context: We currently support 3 levels of comments, and any replies to 3rd level comments become replies to the parent comment, with quote text automatically inserted referring to the comment you actually replied to.

Prior to this commit we were sorting 3rd level comments by number of upvotes which made some conversations difficult to follow:

<img width="696" alt="Screen Shot 2022-01-03 at 12 16 09 PM" src="https://user-images.githubusercontent.com/22990196/147970452-640d600b-2d3d-41f6-b4f1-129335a1a34c.png">

This commit sorts 3rd level comments by created_date, which should fix this issue.