### PR TITLE
Fixed changing filters sometimes not sending a network request

### DIFF
--- a/components/UnifiedDocFeed/UnifiedDocFeedContainer.tsx
+++ b/components/UnifiedDocFeed/UnifiedDocFeedContainer.tsx
@@ -152,7 +152,7 @@ function UnifiedDocFeedContainer({
       },
       page: 1 /* when force updating, start from page 1 */,
     },
-    shouldEscape: isServerLoaded,
+    shouldEscape: false,
     updateOn: [docTypeFilter, hubID, isLoggedIn, subFilters],
   });
 

--- a/components/UnifiedDocFeed/utils/UnifiedDocFeedUtil.tsx
+++ b/components/UnifiedDocFeed/utils/UnifiedDocFeedUtil.tsx
@@ -83,6 +83,8 @@ export const useEffectForceUpdate = ({
   updateOn: any[];
 }): void => {
   useEffect((): void => {
-    fetchUnifiedDocs(fetchParams);
+    if (!shouldEscape) {
+      fetchUnifiedDocs(fetchParams);
+    }
   }, [...updateOn]);
 };


### PR DESCRIPTION
@calvinhlee23 do you know what this `shouldEscape` condition was used for? It seems to cause issues where sometimes changing filters won't send a network request.