### PR TITLE
Including nested replies in comment count for threads and css updates

### DIFF
--- a/components/Threads/CommentEntry.js
+++ b/components/Threads/CommentEntry.js
@@ -579,8 +579,6 @@ class CommentEntry extends Component {
               <div
                 className={css(
                   styles.threadline,
-                  this.state.revealReply && styles.activeThreadline,
-                  this.state.hovered && styles.hoverThreadline,
                   noVote && styles.threadlineNoVote
                 )}
                 onClick={this.toggleReplyView}

--- a/components/Threads/DiscussionEntry.js
+++ b/components/Threads/DiscussionEntry.js
@@ -471,9 +471,10 @@ class DiscussionEntry extends Component {
       store: inlineCommentStore,
     } = this.props;
     const commentCount =
-      this.state.comments.length > data.comment_count
-        ? this.state.comments.length
-        : data.comment_count;
+      data.comment_count +
+      data.comments
+        .map((comment) => comment.reply_count)
+        .reduce((a, b) => a + b, 0);
     const date = data.created_date;
     const title = data.title;
     const body = data.source === "twitter" ? data.plain_text : data.text;
@@ -524,13 +525,7 @@ class DiscussionEntry extends Component {
                 )}
                 onClick={this.toggleCommentView}
               >
-                <div
-                  className={css(
-                    styles.threadline,
-                    this.state.revealComment && styles.activeThreadline,
-                    this.state.hovered && styles.hoverThreadline
-                  )}
-                />
+                <div className={css(styles.threadline)} />
               </div>
             </div>
           </div>

--- a/components/Threads/ThreadActionBar.js
+++ b/components/Threads/ThreadActionBar.js
@@ -67,21 +67,14 @@ class ThreadActionBar extends Component {
         onMouseEnter={onCountHover}
         onMouseLeave={onCountHover}
       >
-        <span
-          className={css(styles.iconChat, showChildrenState && styles.active)}
-          id={"chatIcon"}
-        >
+        <span className={css(styles.iconChat)} id={"chatIcon"}>
           {icons.comments}
         </span>
         <span
-          className={css(
-            styles.text,
-            small && styles.smallReply,
-            showChildrenState && styles.active
-          )}
+          className={css(styles.text, small && styles.smallReply)}
           id={"text"}
         >
-          {this.formatCommentCount(count, comment)}
+          {`Replies (${count}${showChildrenState ? "" : " hidden"})`}
         </span>
       </div>
     );
@@ -124,21 +117,6 @@ class ThreadActionBar extends Component {
         </span>
       </div>
     );
-  };
-
-  formatCommentCount = (count, isComment) => {
-    const suffix = isComment
-      ? count === 0 || count > 1
-        ? "Replies"
-        : "Reply"
-      : "Comments";
-
-    if (count < 1 || doesNotExist(count)) {
-      return `${suffix} (${count})`;
-    } else if (count < 2) {
-      return `${suffix} (${count})`;
-    }
-    return `${suffix} (${count})`;
   };
 
   toggleReplyBox = () => {


### PR DESCRIPTION
### Including nested replies in comment count for threads:
<img width="703" alt="Screen Shot 2022-01-06 at 2 40 47 PM" src="https://user-images.githubusercontent.com/22990196/148455989-523ccbc3-5792-4f9d-bf02-9b8b3fe8ea5b.png">

### Showing "hidden" when a thread is collapsed, threadline and comment count are always grey unless hovered:
<img width="692" alt="Screen Shot 2022-01-06 at 2 41 05 PM" src="https://user-images.githubusercontent.com/22990196/148456020-a24fb0a6-4dc4-4d4d-b381-44e6a0cdb6d9.png">