### PR TITLE
Turn off latex rendering until we have a mechanism to toggle on/off

### DIFF
--- a/config/utils/latex.js
+++ b/config/utils/latex.js
@@ -102,6 +102,25 @@ const splitAtDelimiters = function (startData, leftDelim, rightDelim, display) {
 };
 
 export const parseMath = (str) => {
+  return str;
+  /*
+    FIXME: Temporarily turning off katex rendering.
+    Some papers are negatively affected which causes bad rendering.
+    Before this turned on, we should have a featured to toggle on/off
+    katex in some papers.
+    Some characters are being misinterpreted by the katex renderer.
+    Example string that leads to bad rendering:
+
+    "
+    Background: Anterior cruciate ligament (ACL) tears are one of the most devastating injuries seen in the National Basketball Association (NBA). No previous studies have examined the economic impact of ACL tears in the NBA. 
+    Purpose/Hypothesis: The purpose of this study was to examine the economic impact of ACL tears on NBA players and teams by calculating the costs of recovery (COR) and classifying players based on preinjury success level (All-Star or equivalent, starter, or reserve) and salary (in US$ million: <1.5, 1.5-4, or >4 per season). It was hypothesized that players with a lower preinjury salary or primarily a reserve role would have decreased costs, lower rates of return to play (RTP), and shorter careers. 
+    Study Design: Descriptive epidemiology study. 
+    Methods: We reviewed the publicly available records of NBA players treated with ACL reconstruction from 2000 to 2015. Data collected included player demographics, player salaries, statistical performance using player efficiency rating (PER), and specifics regarding time missed and RTP rate. 
+    Results: A total of 35 players met the study inclusion criteria. The cumulative economic loss from ACL injuries in the NBA from 2000 to 2015 was $99 million. The average COR was $2.9 million per player. RTP rate was 91% overall, with 70% retention at 3 years. Players that made a salary of less than $1.5 million per season before the injury had a significant drop in PER (difference of –7), RTP rate of 63%, and only 37% retention at 3 years. Conversely, recovering All-Star players also had a significant drop in PER (–6.2), and no players repeated as All-Stars in the season after ACL reconstruction (0%), although they did have a 100% RTP rate and an average career length of 5.6 seasons postinjury. 
+    Conclusion: While the RTP rate in NBA athletes remained high, ACL reconstruction can result in decreased statistical performance and/or inability to return to prior levels of play. Players who made less than $1.5 million preinjury or played primarily in a reserve role were associated with lower RTP and retention in the NBA at 3 years.
+    "
+  */
+
   if (!str) return str;
 
   let data = [{ type: "text", data: str }];


### PR DESCRIPTION
Some papers such as https://www.researchhub.com/paper/1267056/economic-and-performance-impact-of-anterior-cruciate-ligament-injury-in-national-basketball-association-players break the layout of the site when its abstract is latex rendered.

Temporarily turning off latex until we have a mechanism to toggle off/on on some papers/posts. It does not seem like it is needed across the board atm.

![image](https://user-images.githubusercontent.com/802819/148560049-66a8dcfb-0024-4034-9b95-5a5a65101da0.png)


![image](https://user-images.githubusercontent.com/802819/148560005-728e6c95-5fb1-4e43-9d4c-083e9a03bfaf.png)
