### PR TITLE
Fixed overflowing text and images in posts

### DIFF
--- a/components/CKEditor/CKEditor.css
+++ b/components/CKEditor/CKEditor.css
@@ -411,6 +411,10 @@
 }
 
 /* Custom CSS */
+.ck-content img {
+  max-width: 100%;
+}
+
 .eln .ck.ck-sticky-panel .ck-sticky-panel__content_sticky {
   position: absolute !important;
   z-index: 0 !important;

--- a/components/PostPageCard.js
+++ b/components/PostPageCard.js
@@ -775,7 +775,7 @@ class PostPageCard extends Component {
               </div>
             </div>
           </div>
-          <div className="ck-content">
+          <div className={css(styles.postBody) + " ck-content"}>
             {this.state.showPostEditor ? (
               this.renderPostEditor()
             ) : (
@@ -838,6 +838,9 @@ const styles = StyleSheet.create({
     position: "relative",
     overflow: "visible",
     boxSizing: "border-box",
+  },
+  postBody: {
+    wordBreak: "break-word",
   },
   divider: {
     width: 44,


### PR DESCRIPTION
<img width="1073" alt="Screen Shot 2022-01-12 at 10 59 56 AM" src="https://user-images.githubusercontent.com/22990196/149196067-d75107ff-73e8-4aa7-a7ad-da8b7818288b.png">