### PR TITLE
Fixed error on edit paper page

### DIFF
--- a/components/Paper/Upload/PaperUploadV2Update.tsx
+++ b/components/Paper/Upload/PaperUploadV2Update.tsx
@@ -134,7 +134,7 @@ function PaperUploadV2Update({
   const [formErrors, setFormErrors] = useState<FormErrorState>(
     defaultFormErrorState
   );
-  const [suggestedHubs, setSuggestedHubs] = useState<any>(null);
+  const [suggestedHubs, setSuggestedHubs] = useState<any>([]);
   const currUserAuthorID = !isNullOrUndefined(authRedux.user.author_profile)
     ? authRedux.user.author_profile.id
     : null;


### PR DESCRIPTION
Fixed error where selecting the Hubs dropdown before options have loaded in would crash the page.

<img width="1246" alt="Screen Shot 2022-01-14 at 12 01 15 PM" src="https://user-images.githubusercontent.com/22990196/149570665-f6c31f37-4f23-4acf-803e-1230f6ef547c.png">