### PR TITLE
[Claim Dash] Adding Claim Context

### DIFF
--- a/components/AuthorClaimCaseDashboard/AuthorClaimCaseCard.tsx
+++ b/components/AuthorClaimCaseDashboard/AuthorClaimCaseCard.tsx
@@ -26,7 +26,7 @@ export default function AuthorClaimCaseCard({
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
   const [openModalType, setOpenModalType] =
     useState<ValueOf<typeof AUTHOR_CLAIM_STATUS>>("");
-  const { caseData, requestor, targetAuthor } = authorClaimCase || {};
+  const { caseData, requestor } = authorClaimCase || {};
   const { createdDate, id: caseID, status: caseStatus } = caseData || {};
   const {
     name: requestorName,
@@ -108,7 +108,6 @@ export default function AuthorClaimCaseCard({
           <div className={css(styles.cardSubmain)}>
             <AuthorClaimCaseCardTargetAuthorSection
               caseCreatedDate={formattedCreatedDate}
-              targetAuthor={targetAuthor}
               caseData={caseData}
             />
           </div>

--- a/components/AuthorClaimCaseDashboard/AuthorClaimCaseCard.tsx
+++ b/components/AuthorClaimCaseDashboard/AuthorClaimCaseCard.tsx
@@ -56,6 +56,7 @@ export default function AuthorClaimCaseCard({
     );
   }, [caseStatus]);
 
+
   return (
     <div
       className={css(styles.authorClaimCaseCard)}
@@ -108,6 +109,7 @@ export default function AuthorClaimCaseCard({
             <AuthorClaimCaseCardTargetAuthorSection
               caseCreatedDate={formattedCreatedDate}
               targetAuthor={targetAuthor}
+              caseData={caseData}
             />
           </div>
         ) : null}

--- a/components/AuthorClaimCaseDashboard/AuthorClaimCaseCardTargetAuthorSection.tsx
+++ b/components/AuthorClaimCaseDashboard/AuthorClaimCaseCardTargetAuthorSection.tsx
@@ -4,18 +4,54 @@ import { TargetAuthor } from "./api/AuthorClaimCaseGetCases";
 import colors from "../../config/themes/colors";
 import icons from "../../config/themes/icons";
 import { ReactElement, SyntheticEvent, useMemo } from "react";
+import Link from 'next/link';
 
 type Props = {
   caseCreatedDate: string;
   targetAuthor: TargetAuthor;
+  caseData: any;
 };
 
 export default function AuthorClaimCaseCardTargetAuthorSection({
   caseCreatedDate,
   targetAuthor,
+  caseData,
   targetAuthor: { description, id, name },
 }: Props): ReactElement<"div"> {
   const eduSummary = createUserSummary(targetAuthor) || "N/A";
+
+  const contextHTML = useMemo(() => {
+    const isPaperPageContext = caseData?.context && caseData?.context.context_content_type === 'paper';
+    const isAuthorPageContext = caseData?.context && caseData?.context.context_content_type === 'author';
+    if (isPaperPageContext) {
+      return (
+        <div className={css(styles.marginBottom)}>
+          <span className={css(styles.fontGrey)}>{"Context - "}</span>
+          <Link href={`/paper/${caseData?.context?.id}/${caseData?.context?.slug}`}>
+            <a className={css(styles.link)}>
+              <span className={css(styles.limitChars)}>{caseData?.context?.title}</span> (Paper)
+            </a>
+          </Link>
+        </div>
+      )
+    }
+    else if (isAuthorPageContext) {
+      return (
+        <div className={css(styles.marginBottom)}>
+          <span className={css(styles.fontGrey)}>{"Context - "}</span>
+          <Link href={`/user/${caseData?.context?.id}/overview`}>
+            <a className={css(styles.link)}>
+              <span className={css(styles.limitChars)}>{caseData?.context?.first_name} {caseData?.context?.last_name}</span> (Author)
+            </a>
+          </Link>
+        </div>
+      )
+    }
+    else {
+      return null;
+    }
+  }, [caseData.id])
+
   const authorEducationSummary = useMemo(
     () =>
       eduSummary != null ? (
@@ -50,6 +86,7 @@ export default function AuthorClaimCaseCardTargetAuthorSection({
         <span className={css(styles.fontGrey)}>{"Case Opened - "}</span>
         <span>{caseCreatedDate}</span>
       </div>
+      {contextHTML}
       {authorEducationSummary}
       <div className={css(styles.description, styles.marginBottom)}>
         {description}
@@ -102,6 +139,14 @@ const styles = StyleSheet.create({
   },
   fontGrey: {
     color: colors.GREY(1),
+  },
+  limitChars: {
+    overflow: "hidden",
+    whiteSpace: "nowrap",
+    textOverflow: "ellipsis",
+    maxWidth: 500,
+    display: "inline-block",
+    verticalAlign: "bottom",
   },
   link: {
     color: colors.BLUE(1),

--- a/components/AuthorClaimCaseDashboard/AuthorClaimCaseCardTargetAuthorSection.tsx
+++ b/components/AuthorClaimCaseDashboard/AuthorClaimCaseCardTargetAuthorSection.tsx
@@ -8,129 +8,36 @@ import Link from 'next/link';
 
 type Props = {
   caseCreatedDate: string;
-  targetAuthor: TargetAuthor;
   caseData: any;
 };
 
 export default function AuthorClaimCaseCardTargetAuthorSection({
   caseCreatedDate,
-  targetAuthor,
   caseData,
-  targetAuthor: { description, id, name },
 }: Props): ReactElement<"div"> {
-  const eduSummary = createUserSummary(targetAuthor) || "N/A";
-
-  const contextHTML = useMemo(() => {
-    const isPaperPageContext = caseData?.context && caseData?.context.context_content_type === 'paper';
-    const isAuthorPageContext = caseData?.context && caseData?.context.context_content_type === 'author';
-    if (isPaperPageContext) {
-      return (
-        <div className={css(styles.marginBottom)}>
-          <span className={css(styles.fontGrey)}>{"Context - "}</span>
-          <Link href={`/paper/${caseData?.context?.id}/${caseData?.context?.slug}`}>
-            <a className={css(styles.link)}>
-              <span className={css(styles.limitChars)}>{caseData?.context?.title}</span> (Paper)
-            </a>
-          </Link>
-        </div>
-      )
-    }
-    else if (isAuthorPageContext) {
-      return (
-        <div className={css(styles.marginBottom)}>
-          <span className={css(styles.fontGrey)}>{"Context - "}</span>
-          <Link href={`/user/${caseData?.context?.id}/overview`}>
-            <a className={css(styles.link)}>
-              <span className={css(styles.limitChars)}>{caseData?.context?.first_name} {caseData?.context?.last_name}</span> (Author)
-            </a>
-          </Link>
-        </div>
-      )
-    }
-    else {
-      return null;
-    }
-  }, [caseData.id])
-
-  const authorEducationSummary = useMemo(
-    () =>
-      eduSummary != null ? (
-        <div
-          className={
-            css(styles.educationSummaryContainer, styles.marginBottom) +
-            " clamp2"
-          }
-        >
-          <div className={css(styles.educationSummary) + " clamp2"}>
-            <span className={css(styles.icon)}>{icons.graduationCap}</span>
-            {eduSummary}
-          </div>
-        </div>
-      ) : null,
-    [eduSummary]
-  );
   return (
     <div className={css(styles.targetAuthorSection)}>
       <div className={css(styles.marginBottom)}>
-        <span className={css(styles.fontGrey)}>{"Claiming Author - "}</span>
-        <a
-          className={css(styles.link)}
-          href={`/user/${id}/`}
-          onClick={(e: SyntheticEvent) => e.stopPropagation()}
-          target="_blank"
-        >
-          <span>{name}</span>
-        </a>
+        <span className={css(styles.fontGrey)}>{`Claiming Author - `}</span>
+        <span>{caseData.targetAuthorName}</span>
       </div>
       <div className={css(styles.marginBottom)}>
         <span className={css(styles.fontGrey)}>{"Case Opened - "}</span>
         <span>{caseCreatedDate}</span>
       </div>
-      {contextHTML}
-      {authorEducationSummary}
-      <div className={css(styles.description, styles.marginBottom)}>
-        {description}
-      </div>
+      <div className={css(styles.marginBottom)}>
+        <span className={css(styles.fontGrey)}>{"Paper - "}</span>
+        <Link href={`/paper/${caseData?.paper?.id}/${caseData?.paper?.slug}`}>
+          <a className={css(styles.link)}>
+            <span>{caseData?.paper?.title}</span>
+          </a>
+        </Link>
+      </div>      
     </div>
   );
 }
 
 const styles = StyleSheet.create({
-  targetAuthorSection: {
-    // display: "flex",
-    // flexDirection: "column",
-  },
-  description: {
-    display: "flex",
-    fontFamily: "Roboto",
-    fontSize: 16,
-    fontStyle: "normal",
-    fontWeight: 400,
-    width: "90%",
-  },
-  educationSummaryContainer: {
-    color: colors.GREY(1),
-    display: "flex",
-    marginBottom: 10,
-    "@media only screen and (max-width: 767px)": {
-      // alignItems: "center",
-      // justifyContent: "center",
-      marginBottom: 15,
-      width: "100%",
-    },
-  },
-  educationSummary: {
-    alignItems: "flex-start",
-    color: "#241F3A",
-    display: "flex",
-    fontSize: 15,
-    justifyContent: "center",
-    opacity: 0.7,
-    "@media only screen and (max-width: 415px)": {
-      fontSize: 14,
-      marginTop: 10,
-    },
-  },
   icon: {
     alignItems: "center",
     display: "flex",
@@ -139,14 +46,6 @@ const styles = StyleSheet.create({
   },
   fontGrey: {
     color: colors.GREY(1),
-  },
-  limitChars: {
-    overflow: "hidden",
-    whiteSpace: "nowrap",
-    textOverflow: "ellipsis",
-    maxWidth: 500,
-    display: "inline-block",
-    verticalAlign: "bottom",
   },
   link: {
     color: colors.BLUE(1),

--- a/components/AuthorClaimCaseDashboard/AuthorClaimCaseModal.tsx
+++ b/components/AuthorClaimCaseDashboard/AuthorClaimCaseModal.tsx
@@ -19,6 +19,8 @@ import colors from "~/config/themes/colors";
 import dynamic from "next/dynamic";
 import Loader from "../Loader/Loader";
 import Modal from "react-modal";
+import { MessageActions } from "~/redux/message";
+import { connect } from "react-redux";
 
 const BaseModal = dynamic(() => import("../Modals/BaseModal"));
 
@@ -31,13 +33,15 @@ export type AuthorClaimCaseProps = {
   setLastFetchTime: Function;
 };
 
-export default function AuthorClaimModal({
+function AuthorClaimModal({
   caseID,
   openModalType,
   profileImg,
   requestorName,
   setLastFetchTime,
   setOpenModalType,
+  showMessage,
+  setMessage,
 }: AuthorClaimCaseProps): ReactElement<typeof Modal> {
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
   const { setNumNavInteractions, numNavInteractions } =
@@ -61,6 +65,11 @@ export default function AuthorClaimModal({
           setLastFetchTime(Date.now());
           closeModal(event);
         },
+        onError: (responseMsg) => {
+          showMessage({ load: false, show: true, error: true });
+          setMessage(responseMsg);
+          setIsSubmitting(false);
+        }
       });
     };
   };
@@ -270,3 +279,16 @@ const acceptRejectStyles = StyleSheet.create({
   },
   modalContentStyles: {},
 });
+
+const mapStateToProps = (state) => ({
+});
+
+const mapDispatchToProps = {
+  showMessage: MessageActions.showMessage,
+  setMessage: MessageActions.setMessage,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(AuthorClaimModal);

--- a/components/AuthorClaimCaseDashboard/AuthorClaimCaseModal.tsx
+++ b/components/AuthorClaimCaseDashboard/AuthorClaimCaseModal.tsx
@@ -47,8 +47,14 @@ export default function AuthorClaimModal({
     return (event: SyntheticEvent) => {
       event.stopPropagation(); /* prevents card collapse */
       setIsSubmitting(true);
+      let shouldNotifyUser = true;
+      let updateStatus = actionType;
+      if (actionType == AUTHOR_CLAIM_STATUS.CLOSED) {
+        shouldNotifyUser = false;
+        updateStatus = AUTHOR_CLAIM_STATUS.DENIED;
+      } 
       updateCaseStatus({
-        payload: { caseID, updateStatus: actionType },
+        payload: { caseID, updateStatus, shouldNotifyUser },
         onSuccess: () => {
           setNumNavInteractions(numNavInteractions + 1);
           setIsSubmitting(false);
@@ -82,7 +88,7 @@ export default function AuthorClaimModal({
           <div className={css(acceptRejectStyles.rootContainer)}>
             <div className={css(acceptRejectStyles.titleContainer)}>
               <div className={css(acceptRejectStyles.title)}>
-                {`Are you sure you want to ${verb} the following user?`}
+                {`Are you sure you want to ${verb} claim for the following user?`}
               </div>
             </div>
             <div className={css(acceptRejectStyles.userMediaContianer)}>

--- a/components/AuthorClaimCaseDashboard/api/AuthorClaimCaseGetCases.ts
+++ b/components/AuthorClaimCaseDashboard/api/AuthorClaimCaseGetCases.ts
@@ -11,25 +11,16 @@ export type Requestor = {
   requestorAuthorID: ID;
 };
 
-export type TargetAuthor = {
-  description: string;
-  education: any;
-  headline: any;
-  id: ID;
-  name: string;
-};
-
 export type CaseData = {
   createdDate: string;
   id: ID;
   status: string;
   updatedDate: string;
-  context: any;
+  paper: any;
 };
 
 export type AuthorClaimCase = {
   caseData: CaseData;
-  targetAuthor: TargetAuthor;
   requestor: Requestor;
 };
 
@@ -59,18 +50,10 @@ export function getCases({
             provided_email,
             requestor,
             status,
-            target_author,
             updated_date,
-            context,
+            paper,
+            target_author_name,
           } = caseData;
-          const {
-            description: tAuthorDescription,
-            education: tAuthorEducation,
-            first_name: tAuthorFirstName,
-            headline: tAuthorHeadline,
-            id: tAuthorID,
-            last_name: tAuthorLastName,
-          } = target_author || {};
           const {
             id: requestorID,
             author_profile: {
@@ -86,14 +69,8 @@ export function getCases({
               id,
               status,
               updatedDate: updated_date,
-              context,
-            },
-            targetAuthor: {
-              description: tAuthorDescription,
-              education: tAuthorEducation,
-              headline: tAuthorHeadline,
-              id: tAuthorID,
-              name: `${tAuthorFirstName} ${tAuthorLastName}`,
+              paper,
+              targetAuthorName: target_author_name,
             },
             requestor: {
               name: `${requestorFirstName} ${requestorLastName}`,

--- a/components/AuthorClaimCaseDashboard/api/AuthorClaimCaseGetCases.ts
+++ b/components/AuthorClaimCaseDashboard/api/AuthorClaimCaseGetCases.ts
@@ -24,6 +24,7 @@ export type CaseData = {
   id: ID;
   status: string;
   updatedDate: string;
+  context: any;
 };
 
 export type AuthorClaimCase = {
@@ -60,6 +61,7 @@ export function getCases({
             status,
             target_author,
             updated_date,
+            context,
           } = caseData;
           const {
             description: tAuthorDescription,
@@ -84,6 +86,7 @@ export function getCases({
               id,
               status,
               updatedDate: updated_date,
+              context,
             },
             targetAuthor: {
               description: tAuthorDescription,

--- a/components/AuthorClaimCaseDashboard/api/AuthorClaimCaseUpdateCase.ts
+++ b/components/AuthorClaimCaseDashboard/api/AuthorClaimCaseUpdateCase.ts
@@ -8,19 +8,20 @@ type ApiArgs = {
   payload: {
     caseID: ID;
     updateStatus: ValueOf<typeof AUTHOR_CLAIM_STATUS>;
+    shouldNotifyUser: Boolean;
   };
   onSuccess: Function;
   onError?: Function;
 };
 
 export function updateCaseStatus({
-  payload: { caseID, updateStatus },
+  payload: { caseID, updateStatus, shouldNotifyUser },
   onSuccess,
   onError = emptyFncWithMsg,
 }: ApiArgs): void {
   fetch(
     API.AUTHOR_CLAIM_MODERATORS({}),
-    API.POST_CONFIG({ case_id: caseID, update_status: updateStatus })
+    API.POST_CONFIG({ case_id: caseID, update_status: updateStatus, notify_user: shouldNotifyUser })
   )
     .then(Helpers.checkStatus)
     .then(Helpers.parseJSON)

--- a/components/AuthorClaimCaseDashboard/constants/AuthorClaimStatus.ts
+++ b/components/AuthorClaimCaseDashboard/constants/AuthorClaimStatus.ts
@@ -1,6 +1,7 @@
 export const AUTHOR_CLAIM_ACTION_LABEL = {
   APPROVED: "Approve",
   DENIED: "Reject",
+  CLOSED: "Close",
 };
 
 export const AUTHOR_CLAIM_STATUS = {

--- a/components/AuthorClaimCaseDashboard/util/AuthorClaimCaseUtil.ts
+++ b/components/AuthorClaimCaseDashboard/util/AuthorClaimCaseUtil.ts
@@ -8,7 +8,7 @@ export const getCardAllowedActions = (
 ): Array<ValueOf<typeof AUTHOR_CLAIM_STATUS>> => {
   switch (caseStatus) {
     case OPEN:
-      return [DENIED, APPROVED];
+      return [CLOSED, DENIED, APPROVED];
     default:
       return [];
   }

--- a/components/AuthorClaimModal/AuthorClaimPromptEmail.tsx
+++ b/components/AuthorClaimModal/AuthorClaimPromptEmail.tsx
@@ -11,6 +11,7 @@ import { nullthrows } from "../../config/utils/nullchecks";
 import FormSelect from "../Form/FormSelect";
 import { breakpoints } from "../../config/themes/screen";
 import { MessageActions } from "../../redux/message";
+import { useRouter } from "next/router";
 
 export type AuthorClaimPromptEmailProps = {
   authorData: AuthorDatum[];
@@ -64,6 +65,7 @@ function AuthorClaimPromptEmail({
   setMessage,
   showMessage,
 }: AuthorClaimPromptEmailProps) {
+  const router = useRouter();
   const [formErrors, setFormErrors] = useState<FormError>({
     eduEmail: true,
   });
@@ -86,6 +88,18 @@ function AuthorClaimPromptEmail({
     setShouldDisplayError(false);
   };
 
+  const buildClaimContext = () => {
+    let context = {};
+    if (router.query.paperId) {
+      context['contextContentType'] = 'paper';
+      context['contextContentId'] = router.query.paperId;
+    } else if (router.query.authorId) {
+      context['contextContentType'] = 'author';
+      context['contextContentId'] = router.query.authorId;
+    }
+    return context;
+  }
+
   const handleValidationAndSubmit = (e: SyntheticEvent): void => {
     e.preventDefault();
     if (Object.values(formErrors).every((el: boolean): boolean => !el)) {
@@ -96,12 +110,15 @@ function AuthorClaimPromptEmail({
         showMessage({ show: true, error: true });
         return;
       }
+
+      const claimContext = buildClaimContext();
       const name =
         targetAuthor && targetAuthor.label && targetAuthor.label.split(" ");
       const author = {
         first_name: name && name.length > 0 ? name[0] : null,
         last_name: name && name.length > 1 ? name[1] : null,
       };
+
       setShouldDisplayError(false);
       setIsSubmitting(true);
       createAuthorClaimCase({
@@ -121,6 +138,7 @@ function AuthorClaimPromptEmail({
         ),
         userID,
         author,
+        ...claimContext,
       });
     }
   };

--- a/components/AuthorClaimModal/AuthorClaimPromptEmail.tsx
+++ b/components/AuthorClaimModal/AuthorClaimPromptEmail.tsx
@@ -88,18 +88,6 @@ function AuthorClaimPromptEmail({
     setShouldDisplayError(false);
   };
 
-  const buildClaimContext = () => {
-    let context = {};
-    if (router.query.paperId) {
-      context['contextContentType'] = 'paper';
-      context['contextContentId'] = router.query.paperId;
-    } else if (router.query.authorId) {
-      context['contextContentType'] = 'author';
-      context['contextContentId'] = router.query.authorId;
-    }
-    return context;
-  }
-
   const handleValidationAndSubmit = (e: SyntheticEvent): void => {
     e.preventDefault();
     if (Object.values(formErrors).every((el: boolean): boolean => !el)) {
@@ -110,14 +98,6 @@ function AuthorClaimPromptEmail({
         showMessage({ show: true, error: true });
         return;
       }
-
-      const claimContext = buildClaimContext();
-      const name =
-        targetAuthor && targetAuthor.label && targetAuthor.label.split(" ");
-      const author = {
-        first_name: name && name.length > 0 ? name[0] : null,
-        last_name: name && name.length > 1 ? name[1] : null,
-      };
 
       setShouldDisplayError(false);
       setIsSubmitting(true);
@@ -132,13 +112,9 @@ function AuthorClaimPromptEmail({
           setIsSubmitting(false);
           onSuccess();
         },
-        targetAuthorID: nullthrows(
-          nullthrows(targetAuthor).id,
-          "targetAuthorID must be present to make a request"
-        ),
         userID,
-        author,
-        ...claimContext,
+        targetAuthorName: targetAuthor.name,
+        targetPaperId: router.query.paperId,
       });
     }
   };

--- a/components/AuthorClaimModal/api/authorClaimCaseCreate.ts
+++ b/components/AuthorClaimModal/api/authorClaimCaseCreate.ts
@@ -9,10 +9,8 @@ type Args = {
   onError?: Function;
   onSuccess?: Function;
   userID: ID;
-  targetAuthorID: ID;
-  author?: Object;
-  contextContentType: string;
-  contextContentId: ID;
+  targetAuthorName: string;
+  targetPaperId: ID;
 };
 
 type Params = {
@@ -21,24 +19,22 @@ type Params = {
   moderator?: ID;
   requestor: ID;
   provided_email: string;
-  target_author: ID;
   author?: Object;
-  context_content_type: string;
-  context_content_id: ID;  
+  target_paper_id: ID;
+  target_author_name: string;
 };
 
 export function createAuthorClaimCase({
   eduEmail,
   onError = emptyFncWithMsg,
   onSuccess = emptyFncWithMsg,
-  targetAuthorID,
   userID,
   author,
-  contextContentType,
-  contextContentId,
+  targetPaperId,
+  targetAuthorName,
 }: Args) {
   let params: Params = {
-    case_type: "AUTHOR_CLAIM",
+    case_type: "PAPER_CLAIM",
     creator: nullthrows(
       userID,
       "UserID must be present to create AuthorClaimCase"
@@ -51,14 +47,9 @@ export function createAuthorClaimCase({
       eduEmail,
       "EduEmail must be present to create AuthorClaimCase"
     ),
-    target_author: targetAuthorID,
-    context_content_type: contextContentType, 
-    context_content_id: contextContentId, 
+    target_paper_id: targetPaperId,
+    target_author_name: targetAuthorName
   };
-
-  if (author) {
-    params.author = author;
-  }
 
   fetch(API.AUTHOR_CLAIM_CASE(), API.POST_CONFIG(params))
     .then(Helpers.checkStatus)

--- a/components/AuthorClaimModal/api/authorClaimCaseCreate.ts
+++ b/components/AuthorClaimModal/api/authorClaimCaseCreate.ts
@@ -11,6 +11,8 @@ type Args = {
   userID: ID;
   targetAuthorID: ID;
   author?: Object;
+  contextContentType: string;
+  contextContentId: ID;
 };
 
 type Params = {
@@ -21,6 +23,8 @@ type Params = {
   provided_email: string;
   target_author: ID;
   author?: Object;
+  context_content_type: string;
+  context_content_id: ID;  
 };
 
 export function createAuthorClaimCase({
@@ -30,6 +34,8 @@ export function createAuthorClaimCase({
   targetAuthorID,
   userID,
   author,
+  contextContentType,
+  contextContentId,
 }: Args) {
   let params: Params = {
     case_type: "AUTHOR_CLAIM",
@@ -46,6 +52,8 @@ export function createAuthorClaimCase({
       "EduEmail must be present to create AuthorClaimCase"
     ),
     target_author: targetAuthorID,
+    context_content_type: contextContentType, 
+    context_content_id: contextContentId, 
   };
 
   if (author) {

--- a/pages/user/[authorId]/[tabName]/index.js
+++ b/pages/user/[authorId]/[tabName]/index.js
@@ -906,13 +906,6 @@ function AuthorPage(props) {
                   )}
                 </div>
                 {doesAuthorHaveUser && authorDescription}
-                {!doesAuthorHaveUser ? (
-                  <ClaimAuthorPopoverLabel
-                    auth={auth}
-                    author={author}
-                    user={user}
-                  />
-                ) : null}
               </div>
             </div>
             <div>


### PR DESCRIPTION
- Rendering associated paper in editor dash. The paper indicates where the claim was opened.
- Removing claim functionality from author page.

<img width="1243" alt="image" src="https://user-images.githubusercontent.com/802819/154613741-51e86288-1461-45da-9043-368fb3596513.png">
