### PR TITLE
All transaction data

### DIFF
--- a/components/Author/Tabs/UserTransactions.js
+++ b/components/Author/Tabs/UserTransactions.js
@@ -76,6 +76,8 @@ class UserTransaction extends Component {
   render() {
     const { transactions, maxCardsToRender, auth } = this.props;
 
+    console.log(transactions);
+
     return (
       <ReactPlaceholder
         ready={transactions && !this.props.fetching}

--- a/components/ResearchCoin/TransactionCard.js
+++ b/components/ResearchCoin/TransactionCard.js
@@ -55,6 +55,8 @@ const TransactionCard = (props) => {
               ? transaction.source?.distribution_type
                   .replaceAll("_", " ")
                   .toLocaleLowerCase()
+              : transaction.source?.to_address
+              ? "Withdrawal"
               : ""}
           </div>
           <div className={css(styles.metatext)}>
@@ -76,26 +78,33 @@ const TransactionCard = (props) => {
             </div>
           )}
           {transaction.source?.to_address && (
-            <div
-              className={css(
-                styles.row,
-                styles.metatext,
-                styles.colorBlack,
-                styles.walletLink
-              )}
-            >
-              Wallet Address:
-              <span className={css(styles.address)}>
-                {transaction.source?.to_address}
-                <span
-                  className={css(styles.infoIcon)}
-                  data-tip="User's wallet address"
-                >
-                  {icons["info-circle"]}
-                  <ReactTooltip />
+            <>
+              <div
+                className={css(
+                  styles.row,
+                  styles.metatext,
+                  styles.colorBlack,
+                  styles.walletLink
+                )}
+              >
+                Wallet Address:
+                <span className={css(styles.address)}>
+                  {transaction.source?.to_address}
+                  <span
+                    className={css(styles.infoIcon)}
+                    data-tip="User's wallet address"
+                  >
+                    {icons["info-circle"]}
+                    <ReactTooltip />
+                  </span>
                 </span>
-              </span>
-            </div>
+              </div>
+              <div
+                className={css(styles.row, styles.metatext, styles.colorBlack)}
+              >
+                {renderStatus(transaction.source.paid_status)}
+              </div>
+            </>
           )}
         </div>
         <div className={css(styles.amountContainer)}>

--- a/components/ResearchCoin/TransactionCard.js
+++ b/components/ResearchCoin/TransactionCard.js
@@ -65,17 +65,17 @@ const TransactionCard = (props) => {
             Last Update:{" "}
             {formatTransactionDate(transformDate(transaction.updated_date))}
           </div>
-          {transaction.transaction_hash && (
+          {transaction.source?.transaction_hash && (
             <div
               className={css(styles.row, styles.metatext, styles.colorBlack)}
             >
               Transaction Details:
               <span className={css(styles.address)}>
-                {transaction.to_address}
+                {transaction.source.transaction_hash}
               </span>
             </div>
           )}
-          {transaction.to_address && (
+          {transaction.source?.to_address && (
             <div
               className={css(
                 styles.row,
@@ -86,7 +86,7 @@ const TransactionCard = (props) => {
             >
               Wallet Address:
               <span className={css(styles.address)}>
-                {transaction.to_address}
+                {transaction.source?.to_address}
                 <span
                   className={css(styles.infoIcon)}
                   data-tip="User's wallet address"

--- a/components/ResearchCoin/TransactionCard.js
+++ b/components/ResearchCoin/TransactionCard.js
@@ -48,7 +48,15 @@ const TransactionCard = (props) => {
     >
       <div className={css(styles.row)}>
         <div className={css(styles.column)}>
-          <div className={css(styles.maintext)}>Withdrawal</div>
+          <div className={css(styles.maintext)}>
+            {transaction.source?.purchase_type === "BOOST"
+              ? "Support"
+              : transaction.source?.distribution_type
+              ? transaction.source?.distribution_type
+                  .replaceAll("_", " ")
+                  .toLocaleLowerCase()
+              : ""}
+          </div>
           <div className={css(styles.metatext)}>
             Created:{" "}
             {formatTransactionDate(transformDate(transaction.created_date))}
@@ -67,26 +75,28 @@ const TransactionCard = (props) => {
               </span>
             </div>
           )}
-          <div
-            className={css(
-              styles.row,
-              styles.metatext,
-              styles.colorBlack,
-              styles.walletLink
-            )}
-          >
-            Wallet Address:
-            <span className={css(styles.address)}>
-              {transaction.to_address}
-              <span
-                className={css(styles.infoIcon)}
-                data-tip="User's wallet address"
-              >
-                {icons["info-circle"]}
-                <ReactTooltip />
+          {transaction.to_address && (
+            <div
+              className={css(
+                styles.row,
+                styles.metatext,
+                styles.colorBlack,
+                styles.walletLink
+              )}
+            >
+              Wallet Address:
+              <span className={css(styles.address)}>
+                {transaction.to_address}
+                <span
+                  className={css(styles.infoIcon)}
+                  data-tip="User's wallet address"
+                >
+                  {icons["info-circle"]}
+                  <ReactTooltip />
+                </span>
               </span>
-            </span>
-          </div>
+            </div>
+          )}
         </div>
         <div className={css(styles.amountContainer)}>
           {transaction.amount}
@@ -206,6 +216,7 @@ const styles = StyleSheet.create({
   maintext: {
     fontWeight: 500,
     marginBottom: 10,
+    textTransform: "capitalize",
     "@media only screen and (max-width: 620px)": {
       fontSize: 16,
     },

--- a/config/api.js
+++ b/config/api.js
@@ -812,6 +812,19 @@ const routes = (BASE_URL) => {
       url = prepURL(url, params);
       return url;
     },
+    TRANSACTIONS: ({ transactionId, page }) => {
+      let url = BASE_URL + "transactions/";
+
+      if (page && typeof page === "number") {
+        url += `?page=${page}`;
+      }
+
+      if (transactionId) {
+        url += `${transactionId}/`;
+      }
+
+      return url;
+    },
     // Ethereum
     WITHDRAW_COIN: ({ transactionId, page }) => {
       let url = BASE_URL + "withdrawal/";

--- a/pages/user/[authorId]/[tabName]/index.js
+++ b/pages/user/[authorId]/[tabName]/index.js
@@ -26,7 +26,7 @@ import Link from "next/link";
 import Loader from "~/components/Loader/Loader";
 import ModeratorDeleteButton from "~/components/Moderator/ModeratorDeleteButton";
 import OrcidConnectButton from "~/components/OrcidConnectButton";
-import UserTransactionsTab from "~/components/Author/Tabs/UserTransactions";
+import UserTransactions from "~/components/Author/Tabs/UserTransactions";
 import AuthorActivityFeed from "~/components/Author/Feed/AuthorActivityFeed";
 import HorizontalTabBar from "~/components/HorizontalTabBar";
 import ReactPlaceholder from "react-placeholder/lib";
@@ -367,7 +367,7 @@ function AuthorPage(props) {
             tabName === "transactions" ? styles.reveal : styles.hidden
           )}
         >
-          <UserTransactionsTab fetching={fetching} />
+          <UserTransactions fetching={fetching} />
         </div>
       )}
     </ComponentWrapper>

--- a/redux/configureStore.js
+++ b/redux/configureStore.js
@@ -12,7 +12,7 @@ export function configureStore(initialState = {}) {
     const logger = createLogger({
       colors: false,
     });
-    middleware.push(logger); // Logger must be the last item in middleware
+    // middleware.push(logger); // Logger must be the last item in middleware
   }
 
   let store = createStore(

--- a/redux/transaction.js
+++ b/redux/transaction.js
@@ -15,14 +15,15 @@ export const TransactionConstants = {
 export const TransactionActions = {
   getWithdrawals: (page = 1, prevState) => {
     return async (dispatch, getState) => {
-      return fetch(API.WITHDRAW_COIN({ page }), API.GET_CONFIG())
+      return fetch(API.TRANSACTIONS({ page }), API.GET_CONFIG())
         .then(Helpers.checkStatus)
         .then(Helpers.parseJSON)
         .then((res) => {
+          console.log(res.results);
           return dispatch({
             type: TransactionConstants.GET_WITHDRAWALS,
             payload: {
-              userBalance: res.user.balance,
+              // userBalance: res.user.balance,
               withdrawals: [...res.results],
               count: res.count,
               next: res.next,
@@ -30,6 +31,7 @@ export const TransactionActions = {
           });
         })
         .catch((err) => {
+          console.log(err);
           return dispatch({
             type: TransactionConstants.GET_WITHDRAWALS,
             payload: {


### PR DESCRIPTION
Changing the frontend to get back all transaction data, not just withdrawals. 

This allows users to see what earned them RSC and also what they spent their RSC on. 

Currently doesn't have any links to papers / comments but working on getting that in too.

<img width="1274" alt="Screen Shot 2022-02-17 at 9 39 08 PM" src="https://user-images.githubusercontent.com/2453737/154624475-aed7ce39-99fe-45f6-832d-bf6e6d4dd837.png">


