### PR TITLE
[Feed][Bugfix] - Prefetch local var resetting on component rerender

### DIFF
--- a/components/UnifiedDocFeed/UnifiedDocFeedContainer.tsx
+++ b/components/UnifiedDocFeed/UnifiedDocFeedContainer.tsx
@@ -122,9 +122,9 @@ function UnifiedDocFeedContainer({
       },
       page: page + 1,
     },
-    shouldPrefetch,
     prevFetchParams,
     setPrevFetchParams,
+    shouldPrefetch,
   });
 
   const firstLoad = useRef(!isServer() && !unifiedDocuments.length);

--- a/components/UnifiedDocFeed/UnifiedDocFeedContainer.tsx
+++ b/components/UnifiedDocFeed/UnifiedDocFeedContainer.tsx
@@ -133,7 +133,7 @@ function UnifiedDocFeedContainer({
   /* NOTE (100): paginationInfo (BE) increments by 20 items. 
      localPage is used to increment by 10 items for UI optimization */
   const shouldPrefetch =
-    page * 2 - 1 === localPage - 1 &&
+    page * 2 - 1 === localPage &&
     hasMore &&
     !unifiedDocsLoading &&
     !isPrefetching;

--- a/components/UnifiedDocFeed/UnifiedDocFeedContainer.tsx
+++ b/components/UnifiedDocFeed/UnifiedDocFeedContainer.tsx
@@ -125,13 +125,18 @@ function UnifiedDocFeedContainer({
     updateOn: [docTypeFilter, hubID, loggedIn, subFilters],
   });
 
-  /* NOTE (100): paginationInfo (BE) increments by 20 items. 
-     localPage is used to increment by 10 items for UI optimization */
   const canShowLoadMoreButton = unifiedDocuments.length > localPage * 10;
-  const shouldPrefetch = page * 2 - 1 === localPage && hasMore && !unifiedDocsLoading
-
   const [prevFetchParams, setPrevFetchParams] =
     useState<UniDocFetchParams | null>(null);
+  const [isPrefetching, setIsPrefetching] = useState<boolean>(false);
+
+  /* NOTE (100): paginationInfo (BE) increments by 20 items. 
+     localPage is used to increment by 10 items for UI optimization */
+  const shouldPrefetch =
+    page * 2 - 1 === localPage - 1 &&
+    hasMore &&
+    !unifiedDocsLoading &&
+    !isPrefetching;
 
   useEffectPrefetchNext({
     fetchParams: {
@@ -154,6 +159,7 @@ function UnifiedDocFeedContainer({
       }): void => {
         setUnifiedDocuments([...unifiedDocuments, ...nextDocs]);
         console.warn("pre: ", [...unifiedDocuments, ...nextDocs]);
+        setIsPrefetch(false);
         setPaginationInfo({
           hasMore: nextPageHasMore,
           isLoading: false,
@@ -167,6 +173,7 @@ function UnifiedDocFeedContainer({
     },
     prevFetchParams,
     setPrevFetchParams,
+    setIsPrefetching,
     shouldPrefetch,
   });
 
@@ -176,7 +183,7 @@ function UnifiedDocFeedContainer({
       setUnifiedDocuments([]);
       setDocTypeFilter(selected);
       setUnifiedDocsLoading(true);
-      // setPrevFetchParams(null); // forces prefetch to be triggered
+      setPrevFetchParams(null); // forces prefetch to be triggered
       setPaginationInfo({
         hasMore: false,
         isLoading: true,

--- a/components/UnifiedDocFeed/UnifiedDocFeedContainer.tsx
+++ b/components/UnifiedDocFeed/UnifiedDocFeedContainer.tsx
@@ -84,7 +84,8 @@ function UnifiedDocFeedContainer({
     serverLoadedData,
   });
 
-  /* NOTE (100): paginationInfo (BE) increments by 20 items. localPage is used to increment by 10 items for UI optimization */
+  /* NOTE (100): paginationInfo (BE) increments by 20 items. 
+     localPage is used to increment by 10 items for UI optimization */
   const canShowLoadMoreButton = unifiedDocuments.length > localPage * 10;
   const shouldPrefetch = page * 2 - 1 === localPage && hasMore;
 
@@ -210,7 +211,7 @@ function UnifiedDocFeedContainer({
       }),
     [hubName, feed, subFilters, isHomePage]
   );
-
+  console.warn("unifiedDocs: ", unifiedDocuments);
   const renderableUniDoc = unifiedDocuments.slice(0, localPage * 10);
   const cards = getDocumentCard({
     hasSubscribed,

--- a/components/UnifiedDocFeed/UnifiedDocFeedContainer.tsx
+++ b/components/UnifiedDocFeed/UnifiedDocFeedContainer.tsx
@@ -51,7 +51,7 @@ function UnifiedDocFeedContainer({
   );
   const [subFilters, setSubFilters] = useState({
     filterBy: filterOptions[0],
-    scope: scopeOptions[1],
+    scope: scopeOptions[0],
   });
 
   const [paginationInfo, setPaginationInfo] = useState<PaginationInfo>(
@@ -169,8 +169,11 @@ function UnifiedDocFeedContainer({
 
   const onDocTypeFilterSelect = (selected) => {
     if (docTypeFilter !== selected) {
-      setPrevFetchParams(null); // forces prefetch to be triggered
+      // logical ordering
+      setUnifiedDocuments([]);
       setDocTypeFilter(selected);
+      setUnifiedDocsLoading(true);
+      setPrevFetchParams(null); // forces prefetch to be triggered
       setPaginationInfo({
         hasMore: false,
         isLoading: true,
@@ -218,10 +221,6 @@ function UnifiedDocFeedContainer({
     unifiedDocumentData: renderableUniDoc,
   });
 
-  /* we need time check here to ensure that payload formatting does not lead to 
-  UI rendering timing issues since document objects & formmatting can be heavy */
-  const areCardsReadyToBeRendered = !unifiedDocsLoading;
-
   return (
     <div className={css(styles.unifiedDocFeedContainer)}>
       {!hasSubscribed ? (
@@ -254,7 +253,7 @@ function UnifiedDocFeedContainer({
           />
         </div>
       </div>
-      {!areCardsReadyToBeRendered ? (
+      {Boolean(unifiedDocsLoading) ? (
         <div className={css(styles.initPlaceholder)}>
           <UnifiedDocFeedCardPlaceholder color="#efefef" />
           <UnifiedDocFeedCardPlaceholder color="#efefef" />

--- a/components/UnifiedDocFeed/UnifiedDocFeedContainer.tsx
+++ b/components/UnifiedDocFeed/UnifiedDocFeedContainer.tsx
@@ -87,7 +87,7 @@ function UnifiedDocFeedContainer({
   /* NOTE (100): paginationInfo (BE) increments by 20 items. localPage is used to increment by 10 items for UI optimization */
   const canShowLoadMoreButton = unifiedDocuments.length > localPage * 10;
   const shouldPrefetch = page * 2 - 1 === localPage && hasMore;
-  console.warn("hasMore: ", hasMore);
+
   const [prevFetchParams, setPrevFetchParams] =
     useState<UniDocFetchParams | null>(null);
 
@@ -111,7 +111,6 @@ function UnifiedDocFeedContainer({
         documents: nextDocs,
       }): void => {
         setUnifiedDocuments([...unifiedDocuments, ...nextDocs]);
-        console.warn("updatedPage: ", updatedPage);
         setPaginationInfo({
           hasMore: nextPageHasMore,
           isLoading: false,

--- a/components/UnifiedDocFeed/UnifiedDocFeedContainer.tsx
+++ b/components/UnifiedDocFeed/UnifiedDocFeedContainer.tsx
@@ -84,7 +84,6 @@ function UnifiedDocFeedContainer({
     serverLoadedData,
   });
 
-
   const firstLoad = useRef(!isServer() && !unifiedDocuments.length);
 
   /* Force update when hubs or docType changes. start from page 1 */
@@ -109,6 +108,7 @@ function UnifiedDocFeedContainer({
       }): void => {
         setUnifiedDocsLoading(false);
         setUnifiedDocuments(documents);
+        console.warn("forced: ", documents);
         setPaginationInfo({
           hasMore: nextPageHasMore,
           isLoading: false,
@@ -128,7 +128,7 @@ function UnifiedDocFeedContainer({
   /* NOTE (100): paginationInfo (BE) increments by 20 items. 
      localPage is used to increment by 10 items for UI optimization */
   const canShowLoadMoreButton = unifiedDocuments.length > localPage * 10;
-  const shouldPrefetch = page * 2 - 1 === localPage && hasMore;
+  const shouldPrefetch = page * 2 - 1 === localPage && hasMore && !unifiedDocsLoading
 
   const [prevFetchParams, setPrevFetchParams] =
     useState<UniDocFetchParams | null>(null);
@@ -153,6 +153,7 @@ function UnifiedDocFeedContainer({
         documents: nextDocs,
       }): void => {
         setUnifiedDocuments([...unifiedDocuments, ...nextDocs]);
+        console.warn("pre: ", [...unifiedDocuments, ...nextDocs]);
         setPaginationInfo({
           hasMore: nextPageHasMore,
           isLoading: false,
@@ -175,7 +176,7 @@ function UnifiedDocFeedContainer({
       setUnifiedDocuments([]);
       setDocTypeFilter(selected);
       setUnifiedDocsLoading(true);
-      setPrevFetchParams(null); // forces prefetch to be triggered
+      // setPrevFetchParams(null); // forces prefetch to be triggered
       setPaginationInfo({
         hasMore: false,
         isLoading: true,
@@ -213,7 +214,6 @@ function UnifiedDocFeedContainer({
     [hubName, feed, subFilters, isHomePage]
   );
 
-  console.warn("unifiedDocs: ", unifiedDocuments);
   const renderableUniDoc = unifiedDocuments.slice(0, localPage * 10);
   const cards = getDocumentCard({
     hasSubscribed,

--- a/components/UnifiedDocFeed/UnifiedDocFeedContainer.tsx
+++ b/components/UnifiedDocFeed/UnifiedDocFeedContainer.tsx
@@ -108,7 +108,6 @@ function UnifiedDocFeedContainer({
       }): void => {
         setUnifiedDocsLoading(false);
         setUnifiedDocuments(documents);
-        console.warn("forced: ", documents);
         setPaginationInfo({
           hasMore: nextPageHasMore,
           isLoading: false,
@@ -158,7 +157,6 @@ function UnifiedDocFeedContainer({
         documents: nextDocs,
       }): void => {
         setUnifiedDocuments([...unifiedDocuments, ...nextDocs]);
-        console.warn("pre: ", [...unifiedDocuments, ...nextDocs]);
         setIsPrefetching(false);
         setPaginationInfo({
           hasMore: nextPageHasMore,

--- a/components/UnifiedDocFeed/UnifiedDocFeedContainer.tsx
+++ b/components/UnifiedDocFeed/UnifiedDocFeedContainer.tsx
@@ -86,9 +86,8 @@ function UnifiedDocFeedContainer({
 
   /* NOTE (100): paginationInfo (BE) increments by 20 items. localPage is used to increment by 10 items for UI optimization */
   const canShowLoadMoreButton = unifiedDocuments.length > localPage * 10;
-  const shouldPrefetch = page < localPage * 2 && hasMore;
-  const [prevFetchParams, setPrevFetchParams] =
-    useState<UniDocFetchParams | null>(null);
+  const shouldPrefetch = page * 2 - 1 === localPage && hasMore;
+
   useEffectPrefetchNext({
     fetchParams: {
       ...fetchParamsWithoutCallbacks,
@@ -122,8 +121,8 @@ function UnifiedDocFeedContainer({
       page: page + 1,
     },
     shouldPrefetch,
-    prevFetchParams,
-    setPrevFetchParams,
+    // prevFetchParams,
+    // setPrevFetchParams,
   });
 
   const firstLoad = useRef(!isServer() && !unifiedDocuments.length);

--- a/components/UnifiedDocFeed/UnifiedDocFeedContainer.tsx
+++ b/components/UnifiedDocFeed/UnifiedDocFeedContainer.tsx
@@ -11,6 +11,7 @@ import {
   getFilterFromRouter,
   getPaginationInfoFromServerLoaded,
   PaginationInfo,
+  UniDocFetchParams,
   useEffectForceUpdate,
   useEffectPrefetchNext,
   useEffectUpdateStatesOnServerChanges,
@@ -85,7 +86,9 @@ function UnifiedDocFeedContainer({
 
   /* NOTE (100): paginationInfo (BE) increments by 20 items. localPage is used to increment by 10 items for UI optimization */
   const canShowLoadMoreButton = unifiedDocuments.length > localPage * 10;
-  const shouldPrefetch = page * 2 - 1 === localPage && hasMore;
+  const shouldPrefetch = page < localPage * 2 && hasMore;
+  const [prevFetchParams, setPrevFetchParams] =
+    useState<UniDocFetchParams | null>(null);
   useEffectPrefetchNext({
     fetchParams: {
       ...fetchParamsWithoutCallbacks,
@@ -106,6 +109,7 @@ function UnifiedDocFeedContainer({
         documents: nextDocs,
       }): void => {
         setUnifiedDocuments([...unifiedDocuments, ...nextDocs]);
+        console.warn("updatedPage: ", updatedPage);
         setPaginationInfo({
           hasMore: nextPageHasMore,
           isLoading: false,
@@ -118,6 +122,8 @@ function UnifiedDocFeedContainer({
       page: page + 1,
     },
     shouldPrefetch,
+    prevFetchParams,
+    setPrevFetchParams,
   });
 
   const firstLoad = useRef(!isServer() && !unifiedDocuments.length);

--- a/components/UnifiedDocFeed/UnifiedDocFeedContainer.tsx
+++ b/components/UnifiedDocFeed/UnifiedDocFeedContainer.tsx
@@ -87,6 +87,9 @@ function UnifiedDocFeedContainer({
   /* NOTE (100): paginationInfo (BE) increments by 20 items. localPage is used to increment by 10 items for UI optimization */
   const canShowLoadMoreButton = unifiedDocuments.length > localPage * 10;
   const shouldPrefetch = page * 2 - 1 === localPage && hasMore;
+  console.warn("hasMore: ", hasMore);
+  const [prevFetchParams, setPrevFetchParams] =
+    useState<UniDocFetchParams | null>(null);
 
   useEffectPrefetchNext({
     fetchParams: {
@@ -121,8 +124,8 @@ function UnifiedDocFeedContainer({
       page: page + 1,
     },
     shouldPrefetch,
-    // prevFetchParams,
-    // setPrevFetchParams,
+    prevFetchParams,
+    setPrevFetchParams,
   });
 
   const firstLoad = useRef(!isServer() && !unifiedDocuments.length);
@@ -167,6 +170,7 @@ function UnifiedDocFeedContainer({
 
   const onDocTypeFilterSelect = (selected) => {
     if (docTypeFilter !== selected) {
+      setPrevFetchParams(null); // forces prefetch to be triggered
       setDocTypeFilter(selected);
       setPaginationInfo({
         hasMore: false,

--- a/components/UnifiedDocFeed/UnifiedDocFeedContainer.tsx
+++ b/components/UnifiedDocFeed/UnifiedDocFeedContainer.tsx
@@ -159,7 +159,7 @@ function UnifiedDocFeedContainer({
       }): void => {
         setUnifiedDocuments([...unifiedDocuments, ...nextDocs]);
         console.warn("pre: ", [...unifiedDocuments, ...nextDocs]);
-        setIsPrefetch(false);
+        setIsPrefetching(false);
         setPaginationInfo({
           hasMore: nextPageHasMore,
           isLoading: false,

--- a/components/UnifiedDocFeed/api/unifiedDocFetch.js
+++ b/components/UnifiedDocFeed/api/unifiedDocFetch.js
@@ -143,7 +143,7 @@ export default function fetchUnifiedDocs({
   };
   fetchUnifiedDocFeed(PARAMS)
     .then(async (res) => {
-      const { count, next, results: fetchedUnifiedDocs } = res;
+      const { count, next, results: fetchedUnifiedDocs = [] } = res ?? {};
       const voteFormattedDocs = await fetchUserVote(
         filterNull(fetchedUnifiedDocs),
         isLoggedIn

--- a/components/UnifiedDocFeed/utils/UnifiedDocFeedUtil.tsx
+++ b/components/UnifiedDocFeed/utils/UnifiedDocFeedUtil.tsx
@@ -65,11 +65,13 @@ export const useEffectPrefetchNext = ({
   fetchParams,
   prevFetchParams,
   setPrevFetchParams,
+  setIsPrefetching,
   shouldPrefetch,
 }: {
   fetchParams: UniDocFetchParams;
   prevFetchParams: UniDocFetchParams | null;
   setPrevFetchParams: any;
+  setIsPrefetching: (flag: boolean) => void;
   shouldPrefetch: Boolean;
 }): void => {
   const { docTypeFilter: prevDocTypeFilter, subFilters: prevSubFilters } =
@@ -78,12 +80,13 @@ export const useEffectPrefetchNext = ({
 
   useEffect((): void => {
     const readyToPrefetch =
-      prevFetchParams === null ||
-      (shouldPrefetch &&
-        prevDocTypeFilter == docTypeFilter &&
-        prevSubFilters == subFilters);
+      shouldPrefetch &&
+      (prevFetchParams === null ||
+        (prevDocTypeFilter == docTypeFilter && prevSubFilters == subFilters));
+    console.warn("shouldPrefetch: ", shouldPrefetch);
+
     if (readyToPrefetch) {
-      console.warn("Prefetch");
+      setIsPrefetching(true);
       fetchUnifiedDocs(fetchParams);
       setPrevFetchParams(fetchParams);
     }
@@ -128,6 +131,4 @@ const useEffectHandleFetch = ({
   updateOn: any[];
   setUnifiedDocsLoading: any;
   firstLoad: any;
-}): void => {
-
-}
+}): void => {};

--- a/components/UnifiedDocFeed/utils/UnifiedDocFeedUtil.tsx
+++ b/components/UnifiedDocFeed/utils/UnifiedDocFeedUtil.tsx
@@ -63,19 +63,19 @@ export const useEffectUpdateStatesOnServerChanges = ({
 
 export const useEffectPrefetchNext = ({
   fetchParams,
-  shouldPrefetch,
   prevFetchParams,
   setPrevFetchParams,
+  shouldPrefetch,
 }: {
   fetchParams: UniDocFetchParams;
   prevFetchParams: UniDocFetchParams | null;
-  shouldPrefetch: Boolean;
   setPrevFetchParams: any;
+  shouldPrefetch: Boolean;
 }): void => {
   const { docTypeFilter: prevDocTypeFilter, subFilters: prevSubFilters } =
     prevFetchParams ?? {};
   const { docTypeFilter, subFilters } = fetchParams ?? {};
-  
+
   useEffect((): void => {
     const readyToPrefetch =
       prevFetchParams === null ||

--- a/components/UnifiedDocFeed/utils/UnifiedDocFeedUtil.tsx
+++ b/components/UnifiedDocFeed/utils/UnifiedDocFeedUtil.tsx
@@ -83,6 +83,7 @@ export const useEffectPrefetchNext = ({
         prevDocTypeFilter == docTypeFilter &&
         prevSubFilters == subFilters);
     if (readyToPrefetch) {
+      console.warn("Prefetch");
       fetchUnifiedDocs(fetchParams);
       setPrevFetchParams(fetchParams);
     }
@@ -109,9 +110,24 @@ export const useEffectForceUpdate = ({
   useEffect((): void => {
     if (firstLoad?.current) {
       setUnifiedDocsLoading && setUnifiedDocsLoading(true);
+      console.warn("Force Update");
       fetchUnifiedDocs(fetchParams);
     } else if (firstLoad) {
       firstLoad.current = true;
     }
   }, [...updateOn]);
 };
+
+const useEffectHandleFetch = ({
+  fetchParams,
+  updateOn,
+  setUnifiedDocsLoading,
+  firstLoad,
+}: {
+  fetchParams: UniDocFetchParams;
+  updateOn: any[];
+  setUnifiedDocsLoading: any;
+  firstLoad: any;
+}): void => {
+
+}

--- a/components/UnifiedDocFeed/utils/UnifiedDocFeedUtil.tsx
+++ b/components/UnifiedDocFeed/utils/UnifiedDocFeedUtil.tsx
@@ -64,14 +64,14 @@ export const useEffectUpdateStatesOnServerChanges = ({
 export const useEffectPrefetchNext = ({
   fetchParams,
   shouldPrefetch,
+  prevFetchParams,
+  setPrevFetchParams,
 }: {
   fetchParams: UniDocFetchParams;
-  // prevFetchParams: UniDocFetchParams | null;
+  prevFetchParams: UniDocFetchParams | null;
   shouldPrefetch: Boolean;
-  // setPrevFetchParams: any;
+  setPrevFetchParams: any;
 }): void => {
-  const [prevFetchParams, setPrevFetchParams] =
-    useState<UniDocFetchParams | null>(null);
   const { docTypeFilter: prevDocTypeFilter, subFilters: prevSubFilters } =
     prevFetchParams ?? {};
   const { docTypeFilter, subFilters } = fetchParams ?? {};

--- a/components/UnifiedDocFeed/utils/UnifiedDocFeedUtil.tsx
+++ b/components/UnifiedDocFeed/utils/UnifiedDocFeedUtil.tsx
@@ -74,13 +74,17 @@ export const useEffectPrefetchNext = ({
   setIsPrefetching: (flag: boolean) => void;
   shouldPrefetch: Boolean;
 }): void => {
-  const { docTypeFilter: prevDocTypeFilter, subFilters: prevSubFilters } =
-    prevFetchParams ?? {};
-  const { docTypeFilter, subFilters } = fetchParams ?? {};
+  const {
+    docTypeFilter: prevDocTypeFilter,
+    subFilters: prevSubFilters,
+    page: prevPage,
+  } = prevFetchParams ?? {};
+  const { docTypeFilter, subFilters, page } = fetchParams ?? {};
 
   useEffect((): void => {
     const readyToPrefetch =
       shouldPrefetch &&
+      prevPage !== page &&
       (prevFetchParams === null ||
         (prevDocTypeFilter == docTypeFilter && prevSubFilters == subFilters));
     console.warn("shouldPrefetch: ", shouldPrefetch);

--- a/components/UnifiedDocFeed/utils/UnifiedDocFeedUtil.tsx
+++ b/components/UnifiedDocFeed/utils/UnifiedDocFeedUtil.tsx
@@ -75,6 +75,7 @@ export const useEffectPrefetchNext = ({
   const { docTypeFilter: prevDocTypeFilter, subFilters: prevSubFilters } =
     prevFetchParams ?? {};
   const { docTypeFilter, subFilters } = fetchParams ?? {};
+  
   useEffect((): void => {
     const readyToPrefetch =
       prevFetchParams === null ||

--- a/components/UnifiedDocFeed/utils/UnifiedDocFeedUtil.tsx
+++ b/components/UnifiedDocFeed/utils/UnifiedDocFeedUtil.tsx
@@ -1,8 +1,9 @@
-import { isNullOrUndefined, nullthrows } from "~/config/utils/nullchecks";
 import { ID } from "~/config/types/root_types";
+import { isNullOrUndefined, nullthrows } from "~/config/utils/nullchecks";
 import { NextRouter } from "next/router";
 import { UnifiedDocFilters } from "../constants/UnifiedDocFilters";
 import { useEffect } from "react";
+import { useState } from "react";
 import fetchUnifiedDocs from "../api/unifiedDocFetch";
 
 export type UniDocFetchParams = {
@@ -62,15 +63,15 @@ export const useEffectUpdateStatesOnServerChanges = ({
 
 export const useEffectPrefetchNext = ({
   fetchParams,
-  prevFetchParams,
   shouldPrefetch,
-  setPrevFetchParams,
 }: {
   fetchParams: UniDocFetchParams;
-  prevFetchParams: UniDocFetchParams | null;
+  // prevFetchParams: UniDocFetchParams | null;
   shouldPrefetch: Boolean;
-  setPrevFetchParams: any;
+  // setPrevFetchParams: any;
 }): void => {
+  const [prevFetchParams, setPrevFetchParams] =
+    useState<UniDocFetchParams | null>(null);
   const { docTypeFilter: prevDocTypeFilter, subFilters: prevSubFilters } =
     prevFetchParams ?? {};
   const { docTypeFilter, subFilters } = fetchParams ?? {};

--- a/components/UnifiedDocFeed/utils/UnifiedDocFeedUtil.tsx
+++ b/components/UnifiedDocFeed/utils/UnifiedDocFeedUtil.tsx
@@ -87,7 +87,6 @@ export const useEffectPrefetchNext = ({
       prevPage !== page &&
       (prevFetchParams === null ||
         (prevDocTypeFilter == docTypeFilter && prevSubFilters == subFilters));
-    console.warn("shouldPrefetch: ", shouldPrefetch);
 
     if (readyToPrefetch) {
       setIsPrefetching(true);
@@ -117,7 +116,6 @@ export const useEffectForceUpdate = ({
   useEffect((): void => {
     if (firstLoad?.current) {
       setUnifiedDocsLoading && setUnifiedDocsLoading(true);
-      console.warn("Force Update");
       fetchUnifiedDocs(fetchParams);
     } else if (firstLoad) {
       firstLoad.current = true;

--- a/components/UnifiedDocFeed/utils/UnifiedDocFeedUtil.tsx
+++ b/components/UnifiedDocFeed/utils/UnifiedDocFeedUtil.tsx
@@ -62,28 +62,35 @@ export const useEffectUpdateStatesOnServerChanges = ({
 
 export const useEffectPrefetchNext = ({
   fetchParams,
+  prevFetchParams,
   shouldPrefetch,
+  setPrevFetchParams,
 }: {
   fetchParams: UniDocFetchParams;
+  prevFetchParams: UniDocFetchParams | null;
   shouldPrefetch: Boolean;
+  setPrevFetchParams: any;
 }): void => {
-  let prevFetchParams: UniDocFetchParams | null = null;
+  const { docTypeFilter: prevDocTypeFilter, subFilters: prevSubFilters } =
+    prevFetchParams ?? {};
+  const { docTypeFilter, subFilters } = fetchParams ?? {};
   useEffect((): void => {
-    // comparing "memoized" filters to avoid unwanted prefetch
-    const { docTypeFilter: prevDocTypeFilter, subFilters: prevSubFilters } =
-      prevFetchParams ?? {};
-    const { docTypeFilter, subFilters } = fetchParams ?? {};
     const readyToPrefetch =
-      shouldPrefetch &&
-      prevDocTypeFilter === docTypeFilter &&
-      prevSubFilters === subFilters;
-
+      prevFetchParams === null ||
+      (shouldPrefetch &&
+        prevDocTypeFilter == docTypeFilter &&
+        prevSubFilters == subFilters);
     if (readyToPrefetch) {
       fetchUnifiedDocs(fetchParams);
-      prevFetchParams = fetchParams;
+      setPrevFetchParams(fetchParams);
     }
-    
-  }, [shouldPrefetch, fetchParams]);
+  }, [
+    shouldPrefetch,
+    prevDocTypeFilter,
+    prevSubFilters,
+    docTypeFilter,
+    subFilters,
+  ]);
 };
 
 export const useEffectForceUpdate = ({

--- a/components/UnifiedDocFeed/utils/getDocumentCard.tsx
+++ b/components/UnifiedDocFeed/utils/getDocumentCard.tsx
@@ -17,7 +17,6 @@ export function getDocumentCard({
   return filterNull(unifiedDocumentData).map(
     (uniDoc: any, arrIndex: number): UnifiedCard => {
       const formattedDocType = getUnifiedDocType(uniDoc?.document_type ?? null);
-      console.warn("formattedDocType: ", formattedDocType);
       const targetDoc =
         formattedDocType !== "post" ? uniDoc.documents : uniDoc.documents[0];
       const docID = targetDoc.id;

--- a/components/UnifiedDocFeed/utils/getDocumentCard.tsx
+++ b/components/UnifiedDocFeed/utils/getDocumentCard.tsx
@@ -1,8 +1,8 @@
-import FeedCard from "~/components/Author/Tabs/FeedCard";
-import React, { ReactElement } from "react";
-import { StyleSheet } from "aphrodite";
 import { filterNull } from "~/config/utils/nullchecks";
 import { getUnifiedDocType } from "~/config/utils/getUnifiedDocType";
+import { ReactElement } from "react";
+import { StyleSheet } from "aphrodite";
+import FeedCard from "~/components/Author/Tabs/FeedCard";
 
 export type UnifiedCard = ReactElement<typeof FeedCard> | null;
 

--- a/components/UnifiedDocFeed/utils/getDocumentCard.tsx
+++ b/components/UnifiedDocFeed/utils/getDocumentCard.tsx
@@ -17,6 +17,7 @@ export function getDocumentCard({
   return filterNull(unifiedDocumentData).map(
     (uniDoc: any, arrIndex: number): UnifiedCard => {
       const formattedDocType = getUnifiedDocType(uniDoc?.document_type ?? null);
+      console.warn("formattedDocType: ", formattedDocType);
       const targetDoc =
         formattedDocType !== "post" ? uniDoc.documents : uniDoc.documents[0];
       const docID = targetDoc.id;


### PR DESCRIPTION
- Component re-render was resetting locally memoized variable for the prefetch function
- Made the function into a state of the top-level component
- Added force reset on the refetch on doc-type changes