### PR TITLE
Updating start_date on feed to be based on absolute time rather than relative

### DIFF
--- a/components/UnifiedDocFeed/api/unifiedDocFetch.js
+++ b/components/UnifiedDocFeed/api/unifiedDocFetch.js
@@ -18,26 +18,23 @@ const calculateTimeScope = (scope) => {
 
   const scopeId = scope.value;
   const now = moment();
-  const today = moment().startOf("day");
-  const week = moment().startOf("day").subtract(7, "days");
-  const month = moment().startOf("day").subtract(30, "days");
-  const year = moment().startOf("day").subtract(365, "days");
 
   scope.end = now.unix();
   if (scopeId === "day") {
-    scope.start = today.unix();
+    scope.start = moment().subtract(1, "day").unix();
   } else if (scopeId === "week") {
-    scope.start = week.unix();
+    scope.start = moment().subtract(7, "day").unix();
   } else if (scopeId === "month") {
-    scope.start = month.unix();
+    scope.start = moment().subtract(30, "day").unix();
   } else if (scopeId === "year") {
-    scope.start = year.unix();
+    scope.start = moment().subtract(365, "day").unix();
   } else if (scopeId === "all-time") {
     const start = "2019-01-01";
     const diff = now.diff(start, "days") + 1;
     const alltime = now.startOf("day").subtract(diff, "days");
     scope.start = alltime.unix();
   }
+
   return scope;
 };
 


### PR DESCRIPTION
### What?
- At the moment, our time filters are off. For example, if today's date is 03-01 then "This month" will only show things that happened today. 
- I confirmed that reddit works differently. Selecting any time filter will subtract an absolute number of days from today. For example, When applying "This month" in reddit, reddit will show posts in the past 30 days.
- Doing things this way gets around the problem of different client timezones. In NYC "today" means a different epoch than in the west coast.