### PR TITLE
Comment timestamps rounded incorrectly using TimeAgo

### DIFF
--- a/components/DiscussionPostMetadata.js
+++ b/components/DiscussionPostMetadata.js
@@ -23,7 +23,7 @@ import { ModalActions } from "~/redux/modals";
 // Config
 import { createUserSummary } from "~/config/utils/user";
 import { Helpers } from "@quantfive/js-web-config";
-import { timeAgo } from "~/config/utils/dates";
+import { timeSince, timeAgo } from "~/config/utils/dates";
 import API from "~/config/api";
 import colors, { voteWidgetColors } from "~/config/themes/colors";
 import icons from "~/config/themes/icons";
@@ -399,7 +399,8 @@ function formatTimestamp(props) {
   if (props.fullDate) {
     return moment(date).format("MMM D, YYYY");
   }
-  return timeAgo.format(date);
+
+  return timeSince(date);
 }
 
 const HideButton = (props) => {

--- a/config/utils/dates.js
+++ b/config/utils/dates.js
@@ -48,6 +48,36 @@ export function timeAgoStamp(date) {
   }
 }
 
+export function timeSince(date) {
+  const inputDate = moment(date);
+  const now = moment();
+  const minsInOneDay = 1440;
+
+  const deltaInMins = now.diff(inputDate, "minutes");
+  let timeSince = "";
+
+  if (deltaInMins <= 1) {
+    timeSince = "just now";
+  } else if (deltaInMins < 60) {
+    timeSince = Math.floor(deltaInMins);
+    timeSince += timeSince == 1 ? " minute ago" : " minutes ago";
+  } else if (deltaInMins < minsInOneDay) {
+    timeSince = Math.floor(deltaInMins / 60);
+    timeSince += timeSince === 1 ? " hour ago" : " hours ago";
+  } else if (deltaInMins < minsInOneDay * 30) {
+    timeSince = Math.floor(deltaInMins / 60 / 24);
+    timeSince += timeSince === 1 ? " day ago" : " days ago";
+  } else if (deltaInMins < minsInOneDay * 365) {
+    timeSince = Math.floor(deltaInMins / 30 / 60 / 24);
+    timeSince += timeSince === 1 ? " month ago" : " months ago";
+  } else {
+    timeSince = Math.floor(deltaInMins / 30 / 60 / 24 / 12);
+    timeSince += timeSince === 1 ? " year ago" : " years ago";
+  }
+
+  return timeSince;
+}
+
 export function calculateScopeFromSlug(scopeId) {
   let scope = {
     start: 0,


### PR DESCRIPTION
### What?
- Fix for comment timestamps incorrectly rounding. For example, "13 days ago" would be rounded to "1 week ago".
- This leads to incorrect output and also makes it hard to debug the "discussed" filter.
- Confirmed that we do not have a function that does this in the codebase. Also confirmed that daysjs does not have a utility function as such.