### PR TITLE
Kobe/paper page fixes

### DIFF
--- a/components/Document/DocumentHeader.tsx
+++ b/components/Document/DocumentHeader.tsx
@@ -129,50 +129,79 @@ function DocumentHeader({
           </span>
         )}
       </span>
-    )
-  }
+    );
+  };
 
   const buildAuthors = (authors) => {
-    
     if (!Array.isArray(authors)) {
       return [];
     }
 
     const minLengthReqToHide = 4;
-    
-    let primaryAuthors:Array<ReactElement<"div">> = [];
-    primaryAuthors = authors.slice(0,2).map(author => buildAuthorElem(author));
 
-    let secondaryAuthors:Array<ReactElement<"div">> = [];
+    let primaryAuthors: Array<ReactElement<"div">> = [];
+    primaryAuthors = authors
+      .slice(0, 2)
+      .map((author) => buildAuthorElem(author));
+
+    let secondaryAuthors: Array<ReactElement<"div">> = [];
     if (authors.length >= minLengthReqToHide) {
-      secondaryAuthors = authors.slice(2, authors.length-1).map((author) => buildAuthorElem(author));
+      secondaryAuthors = authors
+        .slice(2, authors.length - 1)
+        .map((author) => buildAuthorElem(author));
     }
 
     const primaryAuthorElems = primaryAuthors.map((author, idx) => {
-      const renderComma = (showSecondaryAuthors && authors.length > 2) || (authors.length > 1 && idx < primaryAuthors.length -1);
+      const renderComma =
+        (showSecondaryAuthors && authors.length > 2) ||
+        (authors.length > 1 && idx < primaryAuthors.length - 1);
       return (
-        <>{author}{renderComma ? "," : ""}</>
-      )
+        <>
+          {author}
+          {renderComma ? "," : ""}
+        </>
+      );
     });
-    const secondaryAuthorElems = secondaryAuthors.map((author, idx) => <>{author}{idx < secondaryAuthors.length-1 ? "," : ""}</>)
-    const lastAuthor = authors.length > 2 ? buildAuthorElem(authors[authors.length-1]) : null;
+    const secondaryAuthorElems = secondaryAuthors.map((author, idx) => (
+      <>
+        {author}
+        {idx < secondaryAuthors.length - 1 ? "," : ""}
+      </>
+    ));
+    const lastAuthor =
+      authors.length > 2 ? buildAuthorElem(authors[authors.length - 1]) : null;
 
     return (
       <div className={css(styles.authorsContainer)}>
         {primaryAuthorElems}
-        <div className={css(styles.secondaryAuthors, showSecondaryAuthors && styles.showSecondaryAuthors)}>
+        <div
+          className={css(
+            styles.secondaryAuthors,
+            showSecondaryAuthors && styles.showSecondaryAuthors
+          )}
+        >
           {secondaryAuthorElems}
         </div>
-        {!showSecondaryAuthors && secondaryAuthors.length > 0 &&
-          <div className={css(styles.toggleHiddenAuthorsBtn)} onClick={() => setShowSecondaryAuthors(true)}>+{secondaryAuthors.length} authors</div>
-        }
+        {!showSecondaryAuthors && secondaryAuthors.length > 0 && (
+          <div
+            className={css(styles.toggleHiddenAuthorsBtn)}
+            onClick={() => setShowSecondaryAuthors(true)}
+          >
+            +{secondaryAuthors.length} authors
+          </div>
+        )}
         {lastAuthor && <>,{lastAuthor}</>}
-        {showSecondaryAuthors &&
-          <div className={css(styles.toggleHiddenAuthorsBtn)} onClick={() => setShowSecondaryAuthors(false)}>Show less</div>
-        }
+        {showSecondaryAuthors && (
+          <div
+            className={css(styles.toggleHiddenAuthorsBtn)}
+            onClick={() => setShowSecondaryAuthors(false)}
+          >
+            Show less
+          </div>
+        )}
       </div>
-    )
-  }
+    );
+  };
 
   const authorElems = buildAuthors(authors);
 
@@ -241,7 +270,8 @@ function DocumentHeader({
               <div className={css(styles.metadataRow)}>
                 <div className={css(styles.metaKey)}>Authors</div>
                 <div className={css(styles.metaVal)}>
-                  {authorElems}{` `}
+                  {authorElems}
+                  {` `}
                   {claimableAuthors.length > 0 && (
                     <span
                       className={css(styles.claimProfile)}
@@ -431,8 +461,8 @@ const styles = StyleSheet.create({
     cursor: "pointer",
     ":hover": {
       textDecoration: "underline",
-    }
-  },  
+    },
+  },
   boostAmount: {
     display: "flex",
     alignItems: "center",

--- a/components/Document/SubmissionDetails.tsx
+++ b/components/Document/SubmissionDetails.tsx
@@ -23,7 +23,7 @@ function SubmissionDetails({
   createdDate,
   avatarSize = 30,
 }: Args): ReactElement<"div"> {
-  let showAllHubs =
+  const showAllHubs =
     process.browser && window.innerWidth > breakpoints.medium.int;
 
   const [isHubsDropdownOpen, setIsHubsDropdownOpen] = useState(false);

--- a/components/Document/api/censorDocAPI.ts
+++ b/components/Document/api/censorDocAPI.ts
@@ -27,6 +27,6 @@ export default function censorDocument({
         msg: "Failed to censor document",
         data: { unifiedDocumentId },
       });
-      onError(error)
+      onError(error);
     });
 }

--- a/components/Document/api/restoreDocAPI.ts
+++ b/components/Document/api/restoreDocAPI.ts
@@ -27,6 +27,6 @@ export default function restoreDocument({
         msg: "Failed to restore document",
         data: { unifiedDocumentId },
       });
-      onError(error)
+      onError(error);
     });
 }

--- a/components/TextEditor/QuillTextEditor.js
+++ b/components/TextEditor/QuillTextEditor.js
@@ -320,11 +320,6 @@ class Editor extends Component {
         ) : (
           <Fragment>
             <span className="ql-formats">
-              <select className="ql-header">
-                <option value="2">Heading 1</option>
-                <option value="3">Heading 2</option>
-                <option defaultValue />
-              </select>
               <button className="ql-bold" />
               <button className="ql-italic" />
               <button className="ql-underline" />
@@ -333,7 +328,6 @@ class Editor extends Component {
               <button className="ql-blockquote"></button>
               <button className="ql-code-block"></button>
               <button className="ql-strike"></button>
-              <select className="ql-background"></select>
             </span>
             <span className="ql-formats">
               <button className="ql-list" value="ordered" />

--- a/components/TextEditor/stylesheets/QuillTextEditor.css
+++ b/components/TextEditor/stylesheets/QuillTextEditor.css
@@ -139,6 +139,7 @@
 .ql-editor strong {
   font-size: 16px !important;
   font-weight: 600;
+  line-height: unset;
 }
 
 .ql-editor ul,

--- a/components/TextEditor/stylesheets/QuillTextEditor.css
+++ b/components/TextEditor/stylesheets/QuillTextEditor.css
@@ -135,8 +135,15 @@
 .ql-editor h3,
 .ql-editor h4,
 .ql-editor h5,
-.ql-editor h6 {
+.ql-editor h6,
+.ql-editor strong {
   font-size: 16px !important;
+  font-weight: 600;
+}
+
+.ql-editor ul,
+.ql-editor ol {
+  font-size: 16px;
 }
 
 /* .video-stream {

--- a/components/TextEditor/stylesheets/QuillTextEditor.css
+++ b/components/TextEditor/stylesheets/QuillTextEditor.css
@@ -130,6 +130,15 @@
   }
 }
 
+.ql-editor h1,
+.ql-editor h2,
+.ql-editor h3,
+.ql-editor h4,
+.ql-editor h5,
+.ql-editor h6 {
+  font-size: 16px !important;
+}
+
 /* .video-stream {
   height: 250px;
   width: 400px;


### PR DESCRIPTION
- Showing a max of 3 authors on paper page
- Format: First two authors are primary, followed by secondary authors (hidden) followed by PI (last author, always shown)
- Toggle to show/hide more authors
- Removing "header" option on Quill as well as normalizing headers in quill

**Collapsed**
![image](https://user-images.githubusercontent.com/802819/176579173-590667cb-fd05-4411-ad71-02f2e36b0b27.png)

**Expanded**
![image](https://user-images.githubusercontent.com/802819/176579256-8d48e0ca-459b-4471-8bae-d0e97fa4c126.png)
