### PR TITLE
Change community badge icon from Slack to Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="left">
   <a aria-label="Join the community" href="https://discord.gg/ZcCYgcnUp5">
-    <img alt="" src="https://badgen.net/badge/Join%20the%20community/Slack/yellow?icon=slack">
+    <img alt="Discord Badge" src="https://badgen.net/badge/Join%20the%20community/Discord/yellow?icon=discord">
   </a>
 </p>
 <p align="center">&nbsp;</p>


### PR DESCRIPTION
The link was previously updated in c73de9f1d274e890c56b28568459174b60ceda4f but the label and icon were not.
| Before | After |
| --- | --- |
| <img width="194" alt="image" src="https://user-images.githubusercontent.com/29494270/182364129-74015476-a7ee-4737-9296-b23d4697f37a.png"> | <img width="208" alt="image" src="https://user-images.githubusercontent.com/29494270/182364053-ba5e488f-e221-48d2-ba21-0e4492048e16.png"> |