### PR TITLE
Row selection-related reference manager fixes

### DIFF
--- a/components/ReferenceManager/references/ReferencesContainer.tsx
+++ b/components/ReferenceManager/references/ReferencesContainer.tsx
@@ -526,7 +526,7 @@ function ReferencesContainer({
                           fontSize="20px"
                           style={{ marginRight: 8 }}
                         />
-                        {"Add a reference"}
+                        {"Add reference"}
                       </div>
                     }
                     size={"small"}
@@ -551,8 +551,8 @@ function ReferencesContainer({
                       style={{ marginRight: 8 }}
                     />
                     {isOnOrgTab || isOnMyRefs
-                      ? "Create a folder"
-                      : "Create a sub-folder"}
+                      ? "Create folder"
+                      : "Create folder"}
                   </div>
                   {selectedRows.length > 0 && (
                     <Box sx={{ display: "flex", alignItems: "center", ml: 1 }}>

--- a/components/ReferenceManager/references/ReferencesContainer.tsx
+++ b/components/ReferenceManager/references/ReferencesContainer.tsx
@@ -8,8 +8,7 @@ import {
   faMagnifyingGlass,
   faPlus,
   faFileExport,
-  faXmark,
-  faTrash,
+  faTrashCan,
 } from "@fortawesome/pro-light-svg-icons";
 import {
   Fragment,
@@ -253,13 +252,11 @@ function ReferencesContainer({
     setSelectedRows([]);
   };
 
-  const handleRemove = () => {
-    const folderIds = selectedRows.filter((id) =>
-      String(id).includes("folder")
-    );
-    const referenceIds = selectedRows.filter(
-      (id) => !String(id).includes("folder")
-    );
+  const handleDelete = (rowIds: GridRowId | GridRowId[]) => {
+    const _rowIds = Array.isArray(rowIds) ? rowIds : [rowIds];
+
+    const folderIds = _rowIds.filter((id) => String(id).includes("folder"));
+    const referenceIds = _rowIds.filter((id) => !String(id).includes("folder"));
 
     removeReferenceCitations({
       onError: emptyFncWithMsg,
@@ -361,7 +358,7 @@ function ReferencesContainer({
             </Box>
           }
           modalWidth="300px"
-          onPrimaryButtonClick={handleRemove}
+          onPrimaryButtonClick={() => handleDelete(selectedRows)}
           onSecondaryButtonClick={(): void => setIsRemoveRefModalOpen(false)}
           onClose={(): void => setIsRemoveRefModalOpen(false)}
           primaryButtonConfig={{ label: "Remove" }}
@@ -586,7 +583,7 @@ function ReferencesContainer({
                             },
                           }}
                         >
-                          <FontAwesomeIcon icon={faTrash} />
+                          <FontAwesomeIcon icon={faTrashCan} />
                         </IconButton>
                       </Tooltip>
                     </Box>
@@ -611,6 +608,10 @@ function ReferencesContainer({
                 handleFileDrop={onFileDrop}
                 handleClearSelection={handleClearSelection}
                 handleRowSelection={handleRowSelection}
+                handleDelete={(refId: GridRowId) => {
+                  setSelectedRows([refId]);
+                  setIsRemoveRefModalOpen(true);
+                }}
                 loading={referencesSearchLoading}
               />
             </Box>

--- a/components/ReferenceManager/references/ReferencesContainer.tsx
+++ b/components/ReferenceManager/references/ReferencesContainer.tsx
@@ -272,15 +272,9 @@ function ReferencesContainer({
 
   const handleRowSelection = (ids: (string | number)[]) => {
     setSelectedRows(ids);
-    // const _folderIds = refIds.filter((refId) => refId.includes("folder"));
-    // const _referenceIds = refIds.filter((refId) => !refId.includes("folder"));
-
-    // setSelectedFolderIds(_folderIds);
-    // setSelectedReferenceIDs(_referenceIds);
   };
 
   const handleClearSelection = () => {
-    console.log("handleClearSelection");
     setSelectedRows([]);
   };
 

--- a/components/ReferenceManager/references/ReferencesContainer.tsx
+++ b/components/ReferenceManager/references/ReferencesContainer.tsx
@@ -105,8 +105,13 @@ function ReferencesContainer({
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState<boolean>(false);
   const [isLeftNavOpen, setIsLeftNavOpen] = useState<boolean>(true);
   const [isOrgModalOpen, setIsOrgModalOpen] = useState<boolean>(false);
+  // TODO: Deprecate
   const [selectedFolderIds, setSelectedFolderIds] = useState<any[]>([]);
-  const [selectedReferenceIDs, setSelectedReferenceIDs] = useState<any[]>([]);
+  // TODO: Deprecate
+  const [selectedReferenceIDs, setSelectedReferenceIDs] = useState<
+    (string | number)[]
+  >([]);
+  const [selectedRows, setSelectedRows] = useState<any[]>([]);
   const [isBibModalOpen, setIsBibModalOpen] = useState<boolean>(false);
   const [searchQuery, setSearchQuery] = useState<string>("");
   const [isRemoveRefModalOpen, setIsRemoveRefModalOpen] =
@@ -263,6 +268,20 @@ function ReferencesContainer({
     }
 
     return `Are you sure you want to remove the selected items?`;
+  };
+
+  const handleRowSelection = (ids: (string | number)[]) => {
+    setSelectedRows(ids);
+    // const _folderIds = refIds.filter((refId) => refId.includes("folder"));
+    // const _referenceIds = refIds.filter((refId) => !refId.includes("folder"));
+
+    // setSelectedFolderIds(_folderIds);
+    // setSelectedReferenceIDs(_referenceIds);
+  };
+
+  const handleClearSelection = () => {
+    console.log("handleClearSelection");
+    setSelectedRows([]);
   };
 
   if (!userAllowed) {
@@ -617,9 +636,10 @@ function ReferencesContainer({
               </Box>
               <ReferencesTable
                 createdReferences={createdReferences}
+                rowSelectionModel={selectedRows}
                 handleFileDrop={onFileDrop}
-                setSelectedReferenceIDs={setSelectedReferenceIDs}
-                setSelectedFolderIds={setSelectedFolderIds}
+                handleClearSelection={handleClearSelection}
+                handleRowSelection={handleRowSelection}
                 loading={referencesSearchLoading}
               />
             </Box>

--- a/components/ReferenceManager/references/reference_item/ReferenceItemDrawer.tsx
+++ b/components/ReferenceManager/references/reference_item/ReferenceItemDrawer.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@mui/material";
+import { Button, Typography } from "@mui/material";
 import { ClipLoader } from "react-spinners";
 import { convertHttpToHttps } from "~/config/utils/routing";
 import {
@@ -18,7 +18,6 @@ import {
   sortSchemaFieldKeys,
 } from "../utils/resolveFieldKeyLabels";
 import { snakeCaseToNormalCase, toTitleCase } from "~/config/utils/string";
-import { Typography } from "@mui/material";
 import { updateReferenceCitation } from "../api/updateReferenceCitation";
 import { useReferenceTabContext } from "./context/ReferenceItemDrawerContext";
 import Box from "@mui/material/Box";
@@ -99,10 +98,11 @@ export default function ReferenceItemDrawer({}: Props): ReactElement {
   const tabInputItems = filterNull(
     sortSchemaFieldKeys(Object.keys(localReferenceFields)).map(
       (field_key): ReactElement<typeof ReferenceItemFieldInput> | null => {
-        let label = resolveFieldKeyLabels(field_key),
+        const label = resolveFieldKeyLabels(field_key),
           value = localReferenceFields[field_key],
           isRequired = false;
         // isRequired = requiredFieldsSet.has(field_key);
+
         if (field_key === "raw_oa_json") {
           return null;
         }

--- a/components/ReferenceManager/references/reference_item/ReferenceItemOptsDropdown.tsx
+++ b/components/ReferenceManager/references/reference_item/ReferenceItemOptsDropdown.tsx
@@ -7,13 +7,19 @@ import { IconButton, ListItemIcon, ListItemText } from "@mui/material";
 import MenuList from "@mui/material/MenuList";
 import { faTrashCan } from "@fortawesome/pro-light-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faInfoCircle } from "@fortawesome/pro-regular-svg-icons";
 
 interface Props {
   refId: ID;
   handleDelete: Function;
+  handleMetadataAction: (event) => void;
 }
 
-const ReferenceItemOptsDropdown = ({ refId, handleDelete }: Props) => {
+const ReferenceItemOptsDropdown = ({
+  refId,
+  handleDelete,
+  handleMetadataAction,
+}: Props) => {
   const _handleDelete = (e) => {
     handleDelete(refId);
   };
@@ -52,11 +58,21 @@ const ReferenceItemOptsDropdown = ({ refId, handleDelete }: Props) => {
                 vertical: "top",
                 horizontal: "right",
               }}
+              onClick={(e) => {
+                // For touch devices, we need to stop propagation so that the "row click action" event does not get triggered
+                e.stopPropagation();
+              }}
             >
               <MenuList sx={{ p: 0 }}>
+                <MenuItem onClick={handleMetadataAction} sx={{ columnGap: 0 }}>
+                  <ListItemIcon>
+                    <FontAwesomeIcon icon={faInfoCircle} fontSize={20} />
+                  </ListItemIcon>
+                  <ListItemText>Edit Metadata</ListItemText>
+                </MenuItem>
                 <MenuItem onClick={_handleDelete} sx={{ columnGap: 0 }}>
                   <ListItemIcon>
-                    <FontAwesomeIcon icon={faTrashCan} fontSize={18} />
+                    <FontAwesomeIcon icon={faTrashCan} fontSize={20} />
                   </ListItemIcon>
                   <ListItemText>Delete</ListItemText>
                 </MenuItem>

--- a/components/ReferenceManager/references/reference_item/ReferenceItemOptsDropdown.tsx
+++ b/components/ReferenceManager/references/reference_item/ReferenceItemOptsDropdown.tsx
@@ -4,22 +4,18 @@ import MoreVertIcon from "@mui/icons-material/MoreVert";
 import { ID } from "~/config/types/root_types";
 import PopupState, { bindTrigger, bindMenu } from "material-ui-popup-state";
 import { IconButton, ListItemIcon, ListItemText } from "@mui/material";
-import DeleteForeverOutlinedIcon from "@mui/icons-material/DeleteForeverOutlined";
-import IosShareIcon from "@mui/icons-material/IosShare";
 import MenuList from "@mui/material/MenuList";
+import { faTrashCan } from "@fortawesome/pro-light-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 interface Props {
   refId: ID;
-  onDelete: Function;
-  onExport: Function;
+  handleDelete: Function;
 }
 
-const ReferenceItemOptsDropdown = ({ refId, onDelete, onExport }: Props) => {
-  const handleDelete = (e) => {
-    onDelete();
-  };
-  const handleExport = (e) => {
-    onExport();
+const ReferenceItemOptsDropdown = ({ refId, handleDelete }: Props) => {
+  const _handleDelete = (e) => {
+    handleDelete(refId);
   };
 
   const handleIconButtonClick = (originalOnClick) => (e) => {
@@ -57,16 +53,10 @@ const ReferenceItemOptsDropdown = ({ refId, onDelete, onExport }: Props) => {
                 horizontal: "right",
               }}
             >
-              <MenuList>
-                <MenuItem onClick={handleExport}>
+              <MenuList sx={{ p: 0 }}>
+                <MenuItem onClick={_handleDelete} sx={{ columnGap: 0 }}>
                   <ListItemIcon>
-                    <IosShareIcon sx={{ fontSize: "18px" }} />
-                  </ListItemIcon>
-                  <ListItemText>Export</ListItemText>
-                </MenuItem>
-                <MenuItem onClick={handleDelete} sx={{ columnGap: 0 }}>
-                  <ListItemIcon>
-                    <DeleteForeverOutlinedIcon sx={{ fontSize: "18px" }} />
+                    <FontAwesomeIcon icon={faTrashCan} fontSize={18} />
                   </ListItemIcon>
                   <ListItemText>Delete</ListItemText>
                 </MenuItem>

--- a/components/ReferenceManager/references/reference_item/ReferenceItemOptsDropdown.tsx
+++ b/components/ReferenceManager/references/reference_item/ReferenceItemOptsDropdown.tsx
@@ -1,12 +1,12 @@
 import MenuItem from "@mui/material/MenuItem";
 import Menu from "@mui/material/Menu";
-import MoreVertIcon from '@mui/icons-material/MoreVert';
-import { ID } from '~/config/types/root_types';
-import PopupState, { bindTrigger, bindMenu } from 'material-ui-popup-state';
-import { IconButton, ListItemIcon, ListItemText } from '@mui/material';
-import DeleteForeverOutlinedIcon from '@mui/icons-material/DeleteForeverOutlined';
-import IosShareIcon from '@mui/icons-material/IosShare';
-import MenuList from '@mui/material/MenuList';
+import MoreVertIcon from "@mui/icons-material/MoreVert";
+import { ID } from "~/config/types/root_types";
+import PopupState, { bindTrigger, bindMenu } from "material-ui-popup-state";
+import { IconButton, ListItemIcon, ListItemText } from "@mui/material";
+import DeleteForeverOutlinedIcon from "@mui/icons-material/DeleteForeverOutlined";
+import IosShareIcon from "@mui/icons-material/IosShare";
+import MenuList from "@mui/material/MenuList";
 
 interface Props {
   refId: ID;
@@ -15,18 +15,16 @@ interface Props {
 }
 
 const ReferenceItemOptsDropdown = ({ refId, onDelete, onExport }: Props) => {
-  
-
   const handleDelete = (e) => {
     onDelete();
-  }
+  };
   const handleExport = (e) => {
     onExport();
-  }  
+  };
 
   const handleIconButtonClick = (originalOnClick) => (e) => {
     e.stopPropagation();
-    originalOnClick(e); 
+    originalOnClick(e);
   };
 
   return (
@@ -35,48 +33,50 @@ const ReferenceItemOptsDropdown = ({ refId, onDelete, onExport }: Props) => {
         const originalOnClick = bindTrigger(popupState).onClick;
         return (
           <>
-            <IconButton onClick={handleIconButtonClick(originalOnClick)} sx={{
-              padding: 1,
-              fontSize: "24px",
-              '&:hover': {
-                background: "rgba(25, 118, 210, 0.04) !important",
-              }
-            }}>
+            <IconButton
+              onClick={handleIconButtonClick(originalOnClick)}
+              sx={{
+                padding: 1,
+                fontSize: "24px",
+                "&:hover": {
+                  background: "rgba(25, 118, 210, 0.04) !important",
+                },
+              }}
+            >
               <MoreVertIcon />
             </IconButton>
 
             <Menu
               {...bindMenu(popupState)}
               anchorOrigin={{
-                vertical: 'bottom',
-                horizontal: 'right',
+                vertical: "bottom",
+                horizontal: "right",
               }}
               transformOrigin={{
-                vertical: 'top',
-                horizontal: 'right',
+                vertical: "top",
+                horizontal: "right",
               }}
             >
               <MenuList>
-              <MenuItem onClick={handleExport}>
-                <ListItemIcon >
-                  <IosShareIcon sx={{ fontSize: "18px" }} />
-                </ListItemIcon>
-                <ListItemText>Export</ListItemText>
-              </MenuItem>            
-              <MenuItem onClick={handleDelete} sx={{ columnGap: 0 }}>
-                <ListItemIcon>
+                <MenuItem onClick={handleExport}>
+                  <ListItemIcon>
+                    <IosShareIcon sx={{ fontSize: "18px" }} />
+                  </ListItemIcon>
+                  <ListItemText>Export</ListItemText>
+                </MenuItem>
+                <MenuItem onClick={handleDelete} sx={{ columnGap: 0 }}>
+                  <ListItemIcon>
                     <DeleteForeverOutlinedIcon sx={{ fontSize: "18px" }} />
-                </ListItemIcon>
-                <ListItemText>Delete</ListItemText>
-              </MenuItem>
+                  </ListItemIcon>
+                  <ListItemText>Delete</ListItemText>
+                </MenuItem>
               </MenuList>
             </Menu>
           </>
-
-        )
+        );
       }}
     </PopupState>
-  )
-}
+  );
+};
 
 export default ReferenceItemOptsDropdown;

--- a/components/ReferenceManager/references/reference_table/ReferencesTable.tsx
+++ b/components/ReferenceManager/references/reference_table/ReferencesTable.tsx
@@ -308,7 +308,9 @@ export default function ReferencesTable({
           autoHeight
           checkboxSelection
           rowReordering
-          // disableRowSelectionOnClick
+          isRowSelectable={(params) =>
+            String(params.id).includes("parent") ? false : true
+          }
           columns={columnsFormat}
           sx={DATA_GRID_STYLE_OVERRIDE}
           rows={formattedReferenceRows}
@@ -368,12 +370,16 @@ export default function ReferencesTable({
               const { row: refDataRow } = row;
               const typedRefDataRow = refDataRow as ReferenceTableRowDataType;
 
-              let folderRow = false;
+              let rowType: "FOLDER" | "BACK-TO-PARENT" | "REFERENCE" =
+                "REFERENCE";
               const idAsString = typedRefDataRow!.id!.toString();
 
-              if (idAsString.includes("folder")) {
-                folderRow = true;
+              if (idAsString.includes("parent")) {
+                rowType = "BACK-TO-PARENT";
+              } else if (idAsString.includes("folder")) {
+                rowType = "FOLDER";
               }
+
               if (row.row.id === rowHovered) {
                 const hoveredRow = referenceTableRowData.find(
                   (item) => item.id === row?.row?.id
@@ -383,9 +389,8 @@ export default function ReferencesTable({
                   <div style={{ marginRight: 10 }}>
                     {/* Replace with your actual action buttons */}
                     <Stack direction="row" spacing={0}>
-                      {folderRow ? (
-                        <></>
-                      ) : (
+                      {rowType === "FOLDER" && <></>}
+                      {rowType === "REFERENCE" && hoveredRow && (
                         <>
                           {hoveredRow.attachment && (
                             <Tooltip title="Open" placement="top">
@@ -438,21 +443,25 @@ export default function ReferencesTable({
               return (
                 <GridRow
                   {...row}
+                  selectable={false}
                   draggable={true}
                   style={{
                     background:
                       rowDraggedOver === row.row.id && colors.NEW_BLUE(1),
                     color: rowDraggedOver === row.row.id && "#fff",
                   }}
-                  onDragEnter={() => folderRow && setRowDraggedOver(row.row.id)}
-                  onDragLeave={() => folderRow && setRowDraggedOver(null)}
+                  onDragEnter={() =>
+                    rowType === "FOLDER" && setRowDraggedOver(row.row.id)
+                  }
+                  onDragLeave={() =>
+                    rowType === "FOLDER" && setRowDraggedOver(null)
+                  }
                   onDrag={() => {
                     setDragStarted(true);
                     setRowDragged(row.row.id);
                   }}
-                  onDrop={() => folderRow && rowDropped(row.row)}
+                  onDrop={() => rowType === "FOLDER" && rowDropped(row.row)}
                   onMouseEnter={() => {
-                    console.log("row hovered", row.row.id);
                     setRowHovered(row.row.id);
                   }}
                   onMouseLeave={() => setRowHovered(null)}

--- a/components/ReferenceManager/references/reference_table/ReferencesTable.tsx
+++ b/components/ReferenceManager/references/reference_table/ReferencesTable.tsx
@@ -38,7 +38,6 @@ import DocumentViewer from "~/components/Document/DocumentViewer";
 import { ID } from "~/config/types/root_types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faInfoCircle, faBookOpen } from "@fortawesome/pro-regular-svg-icons";
-import { faMaximize } from "@fortawesome/pro-light-svg-icons";
 import { IconButton, Tooltip } from "@mui/material";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import Stack from "@mui/material/Stack";
@@ -323,6 +322,12 @@ export default function ReferencesTable({
     }
   };
 
+  const handleMetadataAction = ({ event, row }): void => {
+    event.stopPropagation();
+    setReferenceItemDatum(row);
+    setIsDrawerOpen(true);
+  };
+
   const formattedReferenceRows = !isLoading
     ? nullthrows(
         formatReferenceRowData(
@@ -356,7 +361,9 @@ export default function ReferencesTable({
           disableRowSelectionOnClick
           rowReordering
           isRowSelectable={(params) =>
-            String(params.id).includes("parent") ? false : true
+            String(params.id).includes("parent") || params.row.is_loading
+              ? false
+              : true
           }
           columns={columnsFormat}
           sx={DATA_GRID_STYLE_OVERRIDE}
@@ -409,7 +416,10 @@ export default function ReferencesTable({
               } else if (idAsString.includes("folder")) {
                 rowType = "FOLDER";
               }
-              if (row.row.id === rowHovered && !row.row.is_loading) {
+              if (
+                (row.row.id === rowHovered && !row.row.is_loading) ||
+                hasTouchCapability
+              ) {
                 const hoveredRow = referenceTableRowData.find(
                   (item) => item.id === row?.row?.id
                 );
@@ -418,10 +428,9 @@ export default function ReferencesTable({
                   <div style={{ marginRight: 10 }}>
                     {/* Replace with your actual action buttons */}
                     <Stack direction="row" spacing={0}>
-                      {rowType === "FOLDER" && <></>}
                       {rowType === "REFERENCE" && hoveredRow && (
                         <>
-                          {hoveredRow.attachment && (
+                          {hoveredRow.attachment && !hasTouchCapability && (
                             <Tooltip title="Open" placement="top">
                               <IconButton
                                 aria-label="Open"
@@ -443,32 +452,41 @@ export default function ReferencesTable({
                               </IconButton>
                             </Tooltip>
                           )}
-                          <Tooltip title="Edit Metadata" placement="top">
-                            <IconButton
-                              aria-label="Edit Metadata"
-                              sx={{
-                                padding: 1,
-                                fontSize: "22px",
-                                "&:hover": {
-                                  background:
-                                    "rgba(25, 118, 210, 0.04) !important",
-                                },
-                              }}
-                              onClick={(event) => {
-                                event.stopPropagation();
-                                setReferenceItemDatum(hoveredRow);
-                                setIsDrawerOpen(true);
-                              }}
-                            >
-                              <InfoOutlinedIcon fontSize="inherit" />
-                            </IconButton>
-                          </Tooltip>
+                          {!hasTouchCapability && (
+                            <Tooltip title="Edit Metadata" placement="top">
+                              <IconButton
+                                aria-label="Edit Metadata"
+                                sx={{
+                                  padding: 1,
+                                  fontSize: "22px",
+                                  "&:hover": {
+                                    background:
+                                      "rgba(25, 118, 210, 0.04) !important",
+                                  },
+                                }}
+                                onClick={(event) => {
+                                  handleMetadataAction({
+                                    event,
+                                    row: hoveredRow,
+                                  });
+                                }}
+                              >
+                                <FontAwesomeIcon
+                                  icon={faInfoCircle}
+                                  fontSize={20}
+                                />
+                              </IconButton>
+                            </Tooltip>
+                          )}
                         </>
                       )}
 
                       <ReferenceItemOptsDropdown
                         refId={typedRefDataRow.id}
                         handleDelete={handleDelete}
+                        handleMetadataAction={(event) =>
+                          handleMetadataAction({ event, row: hoveredRow })
+                        }
                       />
                     </Stack>
                   </div>

--- a/components/ReferenceManager/references/reference_table/ReferencesTable.tsx
+++ b/components/ReferenceManager/references/reference_table/ReferencesTable.tsx
@@ -400,7 +400,6 @@ export default function ReferencesTable({
               } else if (idAsString.includes("folder")) {
                 rowType = "FOLDER";
               }
-
               if (row.row.id === rowHovered && !row.row.is_loading) {
                 const hoveredRow = referenceTableRowData.find(
                   (item) => item.id === row?.row?.id
@@ -458,7 +457,7 @@ export default function ReferencesTable({
                         </>
                       )}
 
-                      {/* <ReferenceItemOptsDropdown refId={typedRefDataRow.id} /> */}
+                      <ReferenceItemOptsDropdown refId={typedRefDataRow.id} />
                     </Stack>
                   </div>
                 );

--- a/components/ReferenceManager/references/reference_table/ReferencesTable.tsx
+++ b/components/ReferenceManager/references/reference_table/ReferencesTable.tsx
@@ -343,6 +343,8 @@ export default function ReferencesTable({
             },
           }}
           onCellDoubleClick={(params, event, _details): void => {
+            if (params.row.is_loading) return;
+
             const rowId = params.id.toString();
             if (rowId.includes("folder")) {
               openFolder({ row: params.row, event });
@@ -361,6 +363,7 @@ export default function ReferencesTable({
           }}
           rowSelectionModel={rowSelectionModel}
           onRowSelectionModelChange={(ids) => {
+            // Without timeout, double click will not be reached since the state update will interrupt it.
             setTimeout(() => {
               handleRowSelection(ids);
             }, 150);
@@ -380,7 +383,7 @@ export default function ReferencesTable({
                 rowType = "FOLDER";
               }
 
-              if (row.row.id === rowHovered) {
+              if (row.row.id === rowHovered && !row.row.is_loading) {
                 const hoveredRow = referenceTableRowData.find(
                   (item) => item.id === row?.row?.id
                 );
@@ -443,7 +446,6 @@ export default function ReferencesTable({
               return (
                 <GridRow
                   {...row}
-                  selectable={false}
                   draggable={true}
                   style={{
                     background:

--- a/components/ReferenceManager/references/reference_table/ReferencesTable.tsx
+++ b/components/ReferenceManager/references/reference_table/ReferencesTable.tsx
@@ -52,6 +52,7 @@ type Props = {
   rowSelectionModel: (string | number)[];
   handleFileDrop: (files: any[]) => void;
   handleRowSelection: (ref: any) => void;
+  handleDelete: (refId: GridRowId) => void;
   handleClearSelection: () => void;
   loading?: boolean | undefined;
   selectedRows: GridRowId[];
@@ -107,6 +108,7 @@ export default function ReferencesTable({
   selectedRows,
   handleRowSelection,
   handleClearSelection,
+  handleDelete,
   loading,
 }: Props) {
   const {
@@ -464,7 +466,10 @@ export default function ReferencesTable({
                         </>
                       )}
 
-                      <ReferenceItemOptsDropdown refId={typedRefDataRow.id} />
+                      <ReferenceItemOptsDropdown
+                        refId={typedRefDataRow.id}
+                        handleDelete={handleDelete}
+                      />
                     </Stack>
                   </div>
                 );

--- a/components/ReferenceManager/references/reference_table/utils/formatReferenceRowData.tsx
+++ b/components/ReferenceManager/references/reference_table/utils/formatReferenceRowData.tsx
@@ -16,6 +16,7 @@ export type ReferenceTableRowDataType = {
   raw_data?: any;
   actions?: any;
   attachment?: string;
+  is_loading?: boolean;
 };
 
 function formatAuthors(
@@ -102,6 +103,7 @@ function formatLoading(datum): ReferenceTableRowDataType {
     last_author: "load",
     hubs: "load",
     published_date: "load",
+    is_loading: true,
   };
 }
 

--- a/components/ReferenceManager/references/reference_table/utils/referenceTableFormat.tsx
+++ b/components/ReferenceManager/references/reference_table/utils/referenceTableFormat.tsx
@@ -54,11 +54,12 @@ export const columnsFormat: GridColDef[] = [
     sortable: false,
     disableColumnMenu: true,
     flex: 1,
+    minWidth: 150,
     headerAlign: "right",
     width: 150,
     align: "right",
     renderCell: (cell) => {
-      return cell.row.actions;
+      return <div style={{ textAlign: "right" }}>{cell.row.actions}</div>;
     },
   },
 ];

--- a/components/ReferenceManager/references/styles/ReferencesTableStyles.ts
+++ b/components/ReferenceManager/references/styles/ReferencesTableStyles.ts
@@ -3,6 +3,11 @@ export const DATA_GRID_STYLE_OVERRIDE = {
     cursor: "pointer",
   },
 
+  // Hide checkbox for disabled rows
+  ".Mui-disabled.MuiDataGrid-checkboxInput": {
+    display: "none",
+  },
+
   border: "1px solid #E9EAEF",
   // minHeight: "300px",
   "&	.MuiDataGrid-overlayWrapper": {

--- a/config/utils/clickEvent.ts
+++ b/config/utils/clickEvent.ts
@@ -55,10 +55,6 @@ export function useEffectHandleClick({
       const _el = (ref && ref.current) || el;
       if (!_el) return;
 
-      console.log("_el", _el);
-      console.log("e.target", e.target);
-      console.log("e.target", e.target.isConnected);
-
       const _isInsideClick = _el?.contains(e.target) && e.target.isConnected;
       if (_isOutsideClick) {
         onOutsideClick && onOutsideClick();

--- a/config/utils/clickEvent.ts
+++ b/config/utils/clickEvent.ts
@@ -33,7 +33,7 @@ export function isOutsideClick({
     false
   );
 
-  return !(isWithin || clickOnExcluded);
+  return clickedEl.isConnected && !(isWithin || clickOnExcluded);
 }
 
 export function useEffectHandleClick({
@@ -55,7 +55,11 @@ export function useEffectHandleClick({
       const _el = (ref && ref.current) || el;
       if (!_el) return;
 
-      const _isInsideClick = _el?.contains(e.target);
+      console.log("_el", _el);
+      console.log("e.target", e.target);
+      console.log("e.target", e.target.isConnected);
+
+      const _isInsideClick = _el?.contains(e.target) && e.target.isConnected;
       if (_isOutsideClick) {
         onOutsideClick && onOutsideClick();
       } else if (_isInsideClick) {

--- a/config/utils/device.ts
+++ b/config/utils/device.ts
@@ -1,0 +1,13 @@
+import { useEffect, useState } from "react";
+
+export const useHasTouchCapability = () => {
+  const [hasTouchCapability, setHasTouchCapability] = useState(false);
+
+  useEffect(() => {
+    const hasTouchCapability =
+      "ontouchstart" in window || navigator.maxTouchPoints > 0;
+    setHasTouchCapability(hasTouchCapability);
+  }, []);
+
+  return hasTouchCapability;
+};


### PR DESCRIPTION
At a high level, configured row selection mechanism to work like Dropbox and Google Drive for desktop and touch-enabled devices.


- [x] - Single click anywhere in the row selects the whole row
- [x] - Double click on folder to open folder
- [x] - Double click on reference to open viewer
- [x] - Make "Go back to parent" not selectable
- [x] - Disable click actions if row is loading
- [x] - Single click on touch-capable devices triggers desktop double click action
- [x] - Configure meta key selection to allow for multiple selected rows
- [x] - Preventing row actions from being cut off in smaller screens
- [x] - Single state for selected rows instead of two state vars (folders, refs). Two state vars interferes with some DataGrid attributes
- [x] - Show actions by default for touch capable devices
- [x] - Allow multi-row selection on click if touch is enabled
- [x] - Show "more options" (three dots) for touch devices by default
- [x] - Do not show checkbox if row is loading
- [x] - Wire edit metadata, delete to "more options" menu