### PR TITLE
Add Pagination to Hubs

### DIFF
--- a/components/Hubs/api/fetchHubs.js
+++ b/components/Hubs/api/fetchHubs.js
@@ -2,14 +2,17 @@ import API from "~/config/api";
 import { Helpers } from "@quantfive/js-web-config";
 import { emptyFncWithMsg } from "~/config/utils/nullchecks";
 
-export const getHubs = async ({ ordering = "score" }) => {
-  const url = API.HUB({ ordering });
+export const getHubs = async ({ ordering = "score", page }) => {
+  const url = API.HUB({ ordering, page });
 
   return fetch(url, API.GET_CONFIG())
     .then(Helpers.checkStatus)
     .then(Helpers.parseJSON)
     .then(async (resp) => {
       return {
+        count: resp.count,
+        next: resp.next,
+        previous: resp.previous,
         hubs: resp.results,
       };
     })

--- a/components/Hubs/api/fetchHubs.js
+++ b/components/Hubs/api/fetchHubs.js
@@ -2,7 +2,7 @@ import API from "~/config/api";
 import { Helpers } from "@quantfive/js-web-config";
 import { emptyFncWithMsg } from "~/config/utils/nullchecks";
 
-export const getHubs = async ({ ordering = "score", page }) => {
+export const getHubs = async ({ ordering = "-score", page }) => {
   const url = API.HUB({ ordering, page });
 
   return fetch(url, API.GET_CONFIG())

--- a/components/Hubs/api/fetchHubs.js
+++ b/components/Hubs/api/fetchHubs.js
@@ -2,7 +2,10 @@ import API from "~/config/api";
 import { Helpers } from "@quantfive/js-web-config";
 import { emptyFncWithMsg } from "~/config/utils/nullchecks";
 
-export const getHubs = async ({ ordering = "-score", page }) => {
+export const getHubs = async ({
+  ordering = "-paper_count,-discussion_count,id",
+  page,
+}) => {
   const url = API.HUB({ ordering, page });
 
   return fetch(url, API.GET_CONFIG())

--- a/components/shared/Pagination.tsx
+++ b/components/shared/Pagination.tsx
@@ -1,0 +1,22 @@
+import { styled } from "@mui/material/styles";
+import MuiPagination from "@mui/material/Pagination";
+import colors from "~/config/themes/colors";
+
+const Pagination = styled(MuiPagination)(({ theme }) => ({
+  "& .MuiPaginationItem-outlined": {
+    borderColor: colors.GREY(0.4),
+  },
+  "& .MuiPaginationItem-outlined.Mui-selected": {
+    backgroundColor: colors.NEW_BLUE(0.1),
+    color: colors.NEW_BLUE(),
+    borderColor: colors.NEW_BLUE(0.6),
+  },
+  "& .MuiPaginationItem-outlined.Mui-selected:hover, & .MuiPaginationItem-outlined.Mui-selected.Mui-focusVisible":
+    {
+      backgroundColor: colors.NEW_BLUE(0.2),
+      color: colors.NEW_BLUE(),
+      borderColor: colors.NEW_BLUE(0.6),
+    },
+}));
+
+export default Pagination;

--- a/config/api.js
+++ b/config/api.js
@@ -711,7 +711,7 @@ const routes = (BASE_URL) => {
       return url;
     },
 
-    HUB: ({ hubId, search, name, slug, ordering }) => {
+    HUB: ({ hubId, search, name, slug, ordering, page }) => {
       let url = BASE_URL + `hub/`;
 
       if (hubId) {
@@ -734,6 +734,10 @@ const routes = (BASE_URL) => {
 
       if (ordering) {
         url += `ordering=${ordering}&`;
+      }
+
+      if (page) {
+        url += `page=${page}&`;
       }
 
       return url;

--- a/config/api.js
+++ b/config/api.js
@@ -749,8 +749,7 @@ const routes = (BASE_URL) => {
         querystring: params,
       }),
     SORTED_HUB: (params = {}) => {
-      // hard codedlimit to 10
-      let url = BASE_URL + `hub/?page_limit=10&ordering=-score`;
+      let url = BASE_URL + `hub/?ordering=-paper_count,-discussion_count,id`;
 
       return url;
     },

--- a/pages/hubs/index.tsx
+++ b/pages/hubs/index.tsx
@@ -20,7 +20,8 @@ import { ModalActions } from "~/redux/modals";
 import AddHubModal from "~/components/Modals/AddHubModal";
 import { getCurrentUser } from "~/config/utils/getCurrentUser";
 import EditHubModal from "~/components/Modals/EditHubModal";
-import { Pagination } from "@mui/material";
+import Pagination from "~/components/shared/Pagination";
+import { getIsOnMobileScreenSize } from "~/config/utils/getIsOnMobileScreenSize";
 
 type Props = {
   hubs: any[];
@@ -98,6 +99,7 @@ const HubsPage: NextPage<Props> = ({
   const currentUser = getCurrentUser();
   const isModerator = Boolean(currentUser?.moderator);
   const isHubEditor = Boolean(currentUser?.author_profile?.is_hub_editor);
+  const isMobileScreen = getIsOnMobileScreenSize();
 
   const addHub = (newHub) => {
     setParsedHubs([...parsedHubs, parseHub(newHub)]);
@@ -169,6 +171,7 @@ const HubsPage: NextPage<Props> = ({
           direction="bottom-right"
           onSelect={(option) => {
             setSort(option);
+            setPage(1);
           }}
         >
           <div className={css(styles.sortTrigger)}>
@@ -196,6 +199,14 @@ const HubsPage: NextPage<Props> = ({
       <div className={css(styles.pagination)}>
         <Pagination
           count={Math.ceil(count / 40)}
+          variant="outlined"
+          shape="rounded"
+          color="primary"
+          page={page}
+          // limiting boundary and sibling count reduces width of entire component,
+          // which is useful to prevent overflow/wrappping on mobile.
+          boundaryCount={isMobileScreen ? 1 : undefined}
+          siblingCount={isMobileScreen ? 0 : undefined}
           onChange={(event, page) => {
             const fetchHubs = async () => {
               // @ts-ignore
@@ -205,9 +216,11 @@ const HubsPage: NextPage<Props> = ({
               });
               const parsedHubs = hubs.map((hub) => parseHub(hub));
               setParsedHubs(parsedHubs);
+              setPage(page);
+              // scroll to top
+              window.scrollTo({ top: 0 });
             };
             fetchHubs();
-            setPage(page);
           }}
         />
       </div>
@@ -246,9 +259,15 @@ const styles = StyleSheet.create({
     marginLeft: "auto",
   },
   pagination: {
-    marginTop: 16,
+    marginTop: 24,
+    marginBottom: 24,
     display: "flex",
     justifyContent: "flex-end",
+    // mobile
+    [`@media only screen and (max-width: ${breakpoints.small.str})`]: {
+      justifyContent: "center",
+      width: "100%",
+    },
   },
   createHubButtonContainer: {
     display: "flex",

--- a/pages/hubs/index.tsx
+++ b/pages/hubs/index.tsx
@@ -35,7 +35,7 @@ const HubsPage: NextPage<Props> = ({
   count,
 }) => {
   const sortOpts = [
-    { label: "Popular", value: "score" },
+    { label: "Popular", value: "-score" },
     { label: "Name", value: "name" },
   ];
 

--- a/pages/hubs/index.tsx
+++ b/pages/hubs/index.tsx
@@ -36,7 +36,7 @@ const HubsPage: NextPage<Props> = ({
   count,
 }) => {
   const sortOpts = [
-    { label: "Popular", value: "-score" },
+    { label: "Popular", value: "-paper_count,-discussion_count,id" },
     { label: "Name", value: "name" },
   ];
 

--- a/redux/hub.js
+++ b/redux/hub.js
@@ -94,7 +94,6 @@ export const HubActions = {
     };
   },
   getTopHubs: (auth) => {
-    // call returns 10 by default
     return (dispatch) => {
       return fetch(API.SORTED_HUB({}), API.GET_CONFIG())
         .then(Helpers.checkStatus)


### PR DESCRIPTION
Implement pagination on hubs.

## Technical Details
- Created a custom `Pagination` component with custom styling
- Changed `ordering` query param from `score` to `-score` (This is in conjunction with a backend change)
  - `-score` means descending order, which is what we want, we perviously just did some weird stuff on the backend to make this work with `score`.

## Design 
<img width="744" alt="Screenshot 2023-10-26 at 1 50 58 PM" src="https://github.com/ResearchHub/researchhub-web/assets/16143968/91818712-93ff-456d-ac54-aa3a78d63d98">

