### PR TITLE
Fix bug where loader persisted on profile page

### DIFF
--- a/components/Author/Feed/utils/AuthorFeedUtils.js
+++ b/components/Author/Feed/utils/AuthorFeedUtils.js
@@ -30,7 +30,8 @@ export const getNewestCommentTimestamp = (discussionItem) => {
 
 export const formatTimestamp = (timestamp) => {
   if (!timestamp) {
-    return null;
+    // we return "" so that `null` or `undefined` doesn't show on the UI by accident
+    return "";
   }
   const date = new Date(timestamp);
   return timeAgo.format(date);

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -24,7 +24,7 @@ import { useEffect, useRef, useState } from "react";
 import App from "next/app";
 import Base from "./Base";
 import nookies from "nookies";
-import Router, { useRouter } from "next/router";
+import { useRouter } from "next/router";
 import withRedux from "next-redux-wrapper";
 
 if (process.env.ELASTIC_APM_URL) {
@@ -99,7 +99,8 @@ const MyApp = ({
         console.log("route change complete");
       });
 
-      Router.events.on("routeChangeError", () => {
+      router.events.on("routeChangeError", (err) => {
+        clearTimeout(showLoader.current);
         store.dispatch(MessageActions.showMessage({ show: false }));
       });
       containerLoaded.current = true;

--- a/pages/user/[authorId]/[tabName]/index.js
+++ b/pages/user/[authorId]/[tabName]/index.js
@@ -950,8 +950,6 @@ function AuthorPage(props) {
     );
   });
 
-  console.log(name);
-
   return (
     <div
       className={css(styles.profilePageRoot)}


### PR DESCRIPTION
**Fix 1:** There is a bug on the profile page where the loader persists on-screen and doesn't go away.

After debugging I found that the `router.events.on("routeChangeError")` would get called with `"Error: Cancel rendering route ..."`, and `routeChangeComplete` would not get called as a result. So the `showLoader.current` timer wouldn't get cleared and would dispatch a `MessageActions.showMessage({ show: true, load: true })` action.

The reason why we get that error is because we make route changes in two places:

1. `router.push` in [handleTabClick](https://github.com/ResearchHub/researchhub-web/blob/master/pages/user/%5BauthorId%5D/%5BtabName%5D/index.js#L228-L252)

2. using the [href tag](https://github.com/ResearchHub/researchhub-web/blob/master/pages/user/%5BauthorId%5D/%5BtabName%5D/index.js#L169) in the HorizontalTabBar

So one of the route changes gets cancelled.

I'm hesitant to change the routing in-case it breaks something, and it also seemed to make sense to hide the loader and clear the timeout if we encounter a `routeChangeError`, and once I made that change the problem was fixed.

I tested other routes and the loader correctly shows/hides in other cases.

---

**Fix 2:** There was a minor bug where the `user/:id/authored-papers` page would say "null" for the date
- I made the `formatTimestamp` func return `""` since this accounts for all its usages
