### PR TITLE
Bug Fix: Reset query param when changing sorting on hubs

### DIFF
--- a/pages/hubs/index.tsx
+++ b/pages/hubs/index.tsx
@@ -63,7 +63,7 @@ const HubsPage: NextPage<Props> = ({
 
   const firstLoadRef = useRef(true);
 
-  const addQueryParam = ({ param, value }) => {
+  const setQueryParam = ({ param, value }) => {
     // Destructure the current pathname and query
     const { pathname, query } = router;
 
@@ -80,7 +80,7 @@ const HubsPage: NextPage<Props> = ({
   const setPageHubs = async (page) => {
     // @ts-ignore
     setLoading(true);
-    addQueryParam({ param: "page", value: page });
+    setQueryParam({ param: "page", value: page });
     const { hubs } = await getHubs({
       page,
       ordering: sort.value,
@@ -225,6 +225,7 @@ const HubsPage: NextPage<Props> = ({
           direction="bottom-right"
           onSelect={(option) => {
             setSort(option);
+            setQueryParam({ param: "page", value: 1 });
             setPage(1);
           }}
         >


### PR DESCRIPTION
Minor bug where query param wasn't getting reset to page 1 when sorting was changed on hubs.