### PR TITLE
Add ability to remove PDF from citation

### DIFF
--- a/components/ReferenceManager/form/ReferenceItemFieldAttachment.tsx
+++ b/components/ReferenceManager/form/ReferenceItemFieldAttachment.tsx
@@ -1,0 +1,123 @@
+import { faTrashAlt } from "@fortawesome/pro-light-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Box, Typography } from "@mui/material";
+import { StyleSheet, css } from "aphrodite";
+import React, { ReactElement, useState } from "react";
+import { ClipLoader } from "react-spinners";
+import Button from "~/components/Form/Button";
+import colors from "~/config/themes/colors";
+import { convertHttpToHttps } from "~/config/utils/routing";
+
+export type Props = {
+  label?: string;
+  attachmentURL: string | null;
+
+  onRemoveAttachment: () => void;
+};
+
+const ReferenceItemFieldAttachment = ({
+  label = "Attachment",
+  attachmentURL,
+  onRemoveAttachment,
+}: Props): ReactElement => {
+  const [isLoading, setIsLoading] = useState(false);
+
+  return (
+    <Box
+      className={"reference-field-input"}
+      sx={{
+        background: "transparent",
+        marginBottom: "16px",
+        width: "100%",
+      }}
+    >
+      <div className={css(styles.header)}>
+        <Typography
+          color="rgba(36, 31, 58, 1)"
+          fontSize="14px"
+          fontWeight={600}
+          lineHeight="22px"
+          letterSpacing={0}
+          sx={{ background: "transparent" }}
+          width="100%"
+        >
+          {label}
+        </Typography>
+        {!!attachmentURL && (
+          <Button
+            onClick={() => {
+              setIsLoading(true);
+              onRemoveAttachment();
+            }}
+            customButtonStyle={styles.removeButton}
+            variant="text"
+            size="small"
+          >
+            {isLoading ? (
+              <ClipLoader
+                color={colors.BLACK(0.6)}
+                loading={true}
+                size={10}
+                speedMultiplier={0.5}
+              />
+            ) : (
+              <div style={{ display: "flex", alignItems: "center" }}>
+                <FontAwesomeIcon
+                  icon={faTrashAlt}
+                  style={{
+                    color: colors.BLACK(0.6),
+                    fontSize: 14,
+                    marginRight: 4,
+                  }}
+                />
+
+                <div className={css(styles.removeText)}>Remove</div>
+              </div>
+            )}
+          </Button>
+        )}
+      </div>
+      {!attachmentURL ? (
+        <span className={css(styles.emptyText)}>No attachments found.</span>
+      ) : (
+        <div
+          style={{
+            height: 600,
+          }}
+        >
+          <iframe
+            height={"100%"}
+            src={convertHttpToHttps(attachmentURL)}
+            width={"100%"}
+          />
+        </div>
+      )}
+    </Box>
+  );
+};
+
+const styles = StyleSheet.create({
+  header: {
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 8,
+  },
+  removeButton: {
+    padding: "5px 8px",
+    minWidth: 100,
+  },
+  removeText: {
+    color: colors.BLACK(0.6),
+    fontSize: 14,
+    fontWeight: 600,
+    marginLeft: 5,
+  },
+  emptyText: {
+    color: colors.BLACK(0.6),
+    fontSize: 14,
+  },
+});
+
+export default ReferenceItemFieldAttachment;


### PR DESCRIPTION
Decided to just add a "Remove" button within the existing "Edit Metadata" menu since this is where users would go to edit the rest of the citation's contents.

It also simplified the UX/implementation.

### No Attachment
<img width="500" alt="no-attachment" src="https://github.com/ResearchHub/researchhub-web/assets/16143968/300fc8b7-3558-4f1c-bd2a-bd3f90c5644a">

### Has Attachment
<img width="500" alt="attachment" src="https://github.com/ResearchHub/researchhub-web/assets/16143968/f33fc4a3-f2d7-468b-be97-f9f7103b829d">
