### PR TITLE
Allow users to drag and drop .bib files in reference manager

### DIFF
--- a/components/ReferenceManager/references/reference_import_library_modal/ReferenceImportLibraryModal.tsx
+++ b/components/ReferenceManager/references/reference_import_library_modal/ReferenceImportLibraryModal.tsx
@@ -20,11 +20,13 @@ import SuccessPage from "./pages/SuccessPage";
 
 export type Props = {
   isOpen: boolean;
+  droppedBibTeXFiles?: File[];
   onClose?: ({ success }: { success: boolean }) => void;
 };
 
 const ReferenceImportLibraryModal = ({
   isOpen,
+  droppedBibTeXFiles = [],
   onClose,
 }: Props): ReactElement => {
   const currentUser = useSelector((state: RootState) => state.auth?.user);
@@ -46,6 +48,13 @@ const ReferenceImportLibraryModal = ({
     setPage("INTRO");
     setFilenames([]);
   }, [isOpen]);
+
+  useEffect(() => {
+    // if the user has already dropped BibTeX files, skip to upload step.
+    if (droppedBibTeXFiles.length > 0) {
+      onBibTeXFileDrop(droppedBibTeXFiles);
+    }
+  }, [droppedBibTeXFiles]);
 
   const onBibTeXFileDrop = (acceptedFiles: File[] | any[]): void => {
     if (acceptedFiles.length < 1) {

--- a/components/ReferenceManager/references/reference_table/ReferencesTable.tsx
+++ b/components/ReferenceManager/references/reference_table/ReferencesTable.tsx
@@ -267,7 +267,7 @@ export default function ReferencesTable({
 
   return (
     <DroppableZone
-      accept=".pdf"
+      accept=".pdf,.bib"
       fullWidth={true}
       handleFileDrop={handleFileDrop}
       multiple
@@ -298,7 +298,8 @@ export default function ReferencesTable({
             noRowsLabel: (
               <UploadFileDragAndDrop
                 children={""}
-                accept={".pdf"}
+                accept={".pdf,.bib"}
+                fileTypeString="PDF or BibTeX files"
                 handleFileDrop={
                   formattedReferenceRows.length === 0
                     ? handleFileDrop


### PR DESCRIPTION
This was discussed in last Friday's meeting with Brian.

We wanted to allow users to drag and drop BibTeX files into the main view, to increase discoverability and usability.