### PR TITLE
Home page on mobile broken

### DIFF
--- a/components/Author/Tabs/FeedCard.tsx
+++ b/components/Author/Tabs/FeedCard.tsx
@@ -375,6 +375,13 @@ function FeedCard({
                       </div>
                     )}
                   </div>
+                  <div className={css(styles.metadataContainer, styles.mobile)}>
+                    <DocumentHubs
+                      hubs={parsedHubs}
+                      withShowMore={false}
+                      hideOnSmallerResolution={true}
+                    />
+                  </div>
                   <div
                     className={css(
                       styles.metadataContainer,
@@ -445,11 +452,13 @@ function FeedCard({
                           }
                         />
                       )}
-                      <DocumentHubs
-                        hubs={parsedHubs}
-                        withShowMore={false}
-                        hideOnSmallerResolution={true}
-                      />
+                      <div className={css(styles.desktop)}>
+                        <DocumentHubs
+                          hubs={parsedHubs}
+                          withShowMore={false}
+                          hideOnSmallerResolution={true}
+                        />
+                      </div>
                     </div>
 
                     <div
@@ -643,6 +652,7 @@ const styles = StyleSheet.create({
     display: "flex",
     alignItems: "center",
     gap: 10,
+    flexWrap: "wrap",
     // flexWrap: "wrap",
     marginTop: 10,
   },

--- a/components/ContentBadge.tsx
+++ b/components/ContentBadge.tsx
@@ -348,7 +348,7 @@ const styles = StyleSheet.create({
   },
   row: {
     display: "flex",
-    aliggItems: "center",
+    alignItems: "center",
   },
   keepPositionAbsolute: {
     position: "absolute",

--- a/components/Document/lib/DocumentHubs.tsx
+++ b/components/Document/lib/DocumentHubs.tsx
@@ -31,7 +31,7 @@ const DocumentHubs = ({
         <div
           key={index}
           className={css(
-            index === 0 || !hideOnSmallerResolution
+            index === 0 || index === 1 || !hideOnSmallerResolution
               ? [styles.wrapper, styles.primaryHub]
               : [styles.wrapper, styles.secondaryHub]
           )}


### PR DESCRIPTION
Badges were stacking too far. Instead of overflowing them down to the next row (looks strange), moved the hub badge above all other badges on mobile.

![Screenshot 2023-11-16 at 5 54 20 PM](https://github.com/ResearchHub/researchhub-web/assets/2453737/66b415ed-be6e-4e26-bc45-7d4ffa5648a6)
