### PR TITLE
Export references as BibTeX and RIS

### DIFF
--- a/components/ReferenceManager/menu/QuickModal.tsx
+++ b/components/ReferenceManager/menu/QuickModal.tsx
@@ -1,18 +1,13 @@
-import { Box, Button, Modal } from "@mui/material";
+import { Box, Modal } from "@mui/material";
+import { StyleSheet } from "aphrodite";
 import { Fragment, ReactElement, ReactNode } from "react";
+import Button from "~/components/Form/Button";
+import colors from "~/config/themes/colors";
 
 type ButtonConfig = {
-  color?:
-    | "inherit"
-    | "primary"
-    | "secondary"
-    | "success"
-    | "error"
-    | "info"
-    | "warning";
   label?: ReactNode;
   remove?: boolean;
-  size?: "small" | "medium" | "large";
+  size?: "small" | "med" | "large";
   variant?: "text" | "outlined" | "contained";
 };
 
@@ -61,14 +56,15 @@ export default function QuickModal({
             display: "flex",
             justifyContent: "flex-end",
             alignItems: "center",
+            gap: "16px",
           }}
         >
           {!secondaryButtonConfig?.remove && (
             <Button
               variant="text"
-              color="info"
               {...secondaryButtonConfig}
-              sx={{ marginRight: "16px" }}
+              label={null}
+              customLabelStyle={secondaryButtonStyles.button}
               onClick={onSecondaryButtonClick}
             >
               {secondaryButtonConfig?.label ?? "Cancel"}
@@ -77,6 +73,7 @@ export default function QuickModal({
           <Button
             variant="contained"
             {...primaryButtonConfig}
+            label={null}
             onClick={onPrimaryButtonClick}
           >
             {primaryButtonConfig?.label ?? "Confirm"}
@@ -86,3 +83,9 @@ export default function QuickModal({
     </Modal>
   );
 }
+
+const secondaryButtonStyles = StyleSheet.create({
+  button: {
+    color: colors.NEW_BLUE(),
+  },
+});

--- a/components/ReferenceManager/references/ReferencesContainer.tsx
+++ b/components/ReferenceManager/references/ReferencesContainer.tsx
@@ -54,7 +54,6 @@ import QuickModal from "../menu/QuickModal";
 import ReactTooltip from "react-tooltip";
 import ReferenceItemDrawer from "./reference_item/ReferenceItemDrawer";
 import ReferenceManualUploadDrawer from "./reference_uploader/ReferenceManualUploadDrawer";
-import ReferencesBibliographyModal from "./reference_bibliography/ReferencesBibliographyModal";
 import ReferencesTable, { PreloadRow } from "./reference_table/ReferencesTable";
 import withWebSocket from "~/components/withWebSocket";
 import FormInput from "~/components/Form/FormInput";
@@ -71,6 +70,9 @@ import RefManagerCallouts from "../onboarding/RefManagerCallouts";
 import { storeToCookie } from "~/config/utils/storeToCookie";
 import DocumentViewer from "~/components/Document/DocumentViewer";
 import ReferenceImportLibraryModal from "./reference_import_library_modal/ReferenceImportLibraryModal";
+import ExportReferencesModal from "./reference_bibliography/ExportReferencesModal";
+import { downloadBibliography, formatBibliography } from "./reference_bibliography/export";
+import ReferencesBibliographyModal from "./reference_bibliography/ReferencesBibliographyModal";
 
 interface Props {
   showMessage: ({ show, load }) => void;
@@ -228,6 +230,18 @@ function ReferencesContainer({
       },
       orgID: nullthrows(currentOrg).id,
     });
+  };
+
+  /**
+   * Format and download the references into a file
+   */
+  const onExportReferences = (format: "BibTeX" | "RIS"): void => {
+    const selected = referenceTableRowData.filter((row) =>
+      selectedRows.includes(row.id!)
+    );
+    const formatted = formatBibliography(selected, format);
+
+    downloadBibliography(formatted, format);
   };
 
   const inputRef = useRef<HTMLInputElement>(null);
@@ -438,7 +452,6 @@ function ReferencesContainer({
   };
 
   const renderReferencesContainer = () => {
-    console.log(activeProject);
     return (
       <Box
         sx={{
@@ -678,23 +691,53 @@ function ReferencesContainer({
                     <>
                       <div className={css(styles.divider)}> </div>
                       <Box sx={{ display: { xs: "none", md: "block" } }}>
-                        <Button
-                          variant="outlined"
-                          size="med"
-                          customButtonStyle={[styles.button, styles.secondary]}
-                          onClick={() => setIsBibModalOpen(true)}
-                        >
-                          <div
-                            style={{ display: "flex", alignItems: "center" }}
-                          >
-                            <FontAwesomeIcon
-                              icon={faFileExport}
-                              fontSize="18px"
-                              style={{ marginRight: 8 }}
-                            />
-                            Export
-                          </div>
-                        </Button>
+                        <DropdownMenu
+                          menuItemProps={[
+                            {
+                              itemLabel: "Bibliography (APA)",
+                              onClick: (): void => {
+                                setIsBibModalOpen(true);
+                              },
+                            },
+                            {
+                              itemLabel: "BibTeX (.bib)",
+                              onClick: (): void => {
+                                onExportReferences("BibTeX");
+                              },
+                            },
+                            {
+                              itemLabel: "RIS (.ris)",
+                              onClick: (): void => {
+                                onExportReferences("RIS");
+                              },
+                            },
+                          ]}
+                          menuLabel={
+                            <Button
+                              variant="outlined"
+                              size="med"
+                              customButtonStyle={[
+                                styles.button,
+                                styles.secondary,
+                              ]}
+                            >
+                              <div
+                                style={{
+                                  display: "flex",
+                                  alignItems: "center",
+                                }}
+                              >
+                                <FontAwesomeIcon
+                                  icon={faFileExport}
+                                  fontSize="18px"
+                                  style={{ marginRight: 8 }}
+                                />
+                                Export
+                              </div>
+                            </Button>
+                          }
+                          size={"small"}
+                        />
                       </Box>
                       <Box sx={{ display: { xs: "none", md: "block" } }}>
                         <Button
@@ -735,9 +778,26 @@ function ReferencesContainer({
                                   Export
                                 </div>
                               ),
-                              onClick: (): void => {
-                                setIsBibModalOpen(true);
-                              },
+                              subMenuItems: [
+                                {
+                                  itemLabel: "Bibliography (APA)",
+                                  onClick: (): void => {
+                                    setIsBibModalOpen(true);
+                                  },
+                                },
+                                {
+                                  itemLabel: "BibTeX (.bib)",
+                                  onClick: (): void => {
+                                    onExportReferences("BibTeX");
+                                  },
+                                },
+                                {
+                                  itemLabel: "RIS (.ris)",
+                                  onClick: (): void => {
+                                    onExportReferences("RIS");
+                                  },
+                                },
+                              ],
                             },
                             {
                               itemLabel: (

--- a/components/ReferenceManager/references/reference_bibliography/ReferencesBibliographyModal.tsx
+++ b/components/ReferenceManager/references/reference_bibliography/ReferencesBibliographyModal.tsx
@@ -8,6 +8,7 @@ import Cite from "citation-js";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import QuickModal from "../../menu/QuickModal";
 import { ReferenceTableRowDataType } from "../reference_table/utils/formatReferenceRowData";
+import { StyleSheet, css } from "aphrodite";
 
 type Props = {
   isOpen: boolean;
@@ -126,12 +127,14 @@ export default function ReferencesBibliographyModal({
       primaryButtonConfig={{
         label:
           copyButtonStatus === null ? (
-            <div style={{ display: "flex", alignItems: "center" }}>
+            <div className={css(styles.copyButton)}>
               <ContentCopyIcon sx={{ marginRight: "8px" }} fontSize="small" />
               {"Copy"}
             </div>
           ) : (
-            <CheckIcon fontSize="small" />
+            <div className={css(styles.copyButton)}>
+              <CheckIcon fontSize="small" />
+            </div>
           ),
       }}
       onPrimaryButtonClick={onCopyClick}
@@ -139,3 +142,13 @@ export default function ReferencesBibliographyModal({
     />
   );
 }
+
+const styles = StyleSheet.create({
+  copyButton: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    minHeight: "28px",
+    minWidth: "70px",
+  },
+});

--- a/components/ReferenceManager/references/reference_bibliography/export.ts
+++ b/components/ReferenceManager/references/reference_bibliography/export.ts
@@ -1,0 +1,85 @@
+import Cite from "citation-js";
+require("@citation-js/plugin-bibtex");
+require("@citation-js/plugin-ris");
+
+import { filterNullOrUndefinedKeys } from "~/config/utils/nullchecks";
+import { ReferenceTableRowDataType } from "../reference_table/utils/formatReferenceRowData";
+
+export const formatBibliography = (
+  refs: ReferenceTableRowDataType[],
+  format: "APA" | "BibTeX" | "RIS"
+): string[] => {
+  const cite = new Cite();
+  cite.reset();
+
+  const parsed = refs.map((ref) => {
+    const fields = ref.fields ?? {};
+    const result = {
+      ...fields,
+      identifier: [{ type: "doi", id: fields.DOI ?? fields.doi }],
+      journal: { name: fields.journal_abbreviation },
+    };
+    delete result.date;
+    delete result.access_date;
+    // we filter null/undefined/empty because if we don't they can show up
+    // as empty entries in BibTeX
+    return filterNullOrUndefinedKeys(result, { filterEmptyString: true });
+  });
+
+  const formatted = parsed.map((item) => {
+    cite.set(item);
+    if (format === "BibTeX") {
+      return cite.format("bibtex", {
+        format: "text",
+      });
+    }
+    if (format === "RIS") {
+      return cite.format("ris", {
+        format: "text",
+      });
+    }
+    // otherwise it's APA
+    return cite.format("bibliography", {
+      format: "text",
+      template: "apa",
+    });
+  });
+
+  return formatted;
+};
+
+export const downloadBibliography = (
+  bib: string[],
+  format: "APA" | "BibTeX" | "RIS"
+): void => {
+  // convert bibliography to blob
+  let bibliographyText = "";
+  if (format === "BibTeX") {
+    bibliographyText = bib.map((b) => b?.trim()).join("\n\n");
+  } else if (format === "RIS") {
+    bibliographyText = bib.map((b) => b?.trim()).join("\n");
+  } else {
+    return;
+  }
+  const b = new Blob([bibliographyText], { type: "text/plain" });
+  const url = URL.createObjectURL(b);
+
+  // create a link for our script to click
+  const a = document.createElement("a");
+  a.href = url;
+  if (format === "BibTeX") {
+    a.download = "export.bib";
+  } else if (format === "RIS") {
+    a.download = "export.ris";
+  } else {
+    return;
+  }
+
+  // trigger the click
+  document.body.appendChild(a);
+  a.click();
+
+  // cleanup
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+};

--- a/config/utils/nullchecks.ts
+++ b/config/utils/nullchecks.ts
@@ -44,6 +44,40 @@ export function filterNull(arr: Array<any>): Array<any> {
   return arr.filter((el: any): boolean => el != null);
 }
 
+export function filterNullOrUndefinedKeys(
+  obj: any,
+  {
+    filterEmptyString,
+    filterEmptyArray,
+    filterEmptyObject,
+  }: {
+    filterEmptyString?: boolean;
+    filterEmptyArray?: boolean;
+    filterEmptyObject?: boolean;
+  } = {
+    filterEmptyString: false,
+    filterEmptyArray: false,
+    filterEmptyObject: false,
+  }
+): any {
+  return Object.keys(obj).reduce((acc: any, key: string): any => {
+    if (
+      isNullOrUndefined(obj[key]) ||
+      (filterEmptyString && obj[key] === "") ||
+      (filterEmptyArray && Array.isArray(obj[key]) && obj[key].length === 0) ||
+      (filterEmptyObject &&
+        typeof obj[key] === "object" &&
+        Object.keys(obj[key]).length === 0)
+    ) {
+      return acc;
+    }
+    return {
+      ...acc,
+      [key]: obj[key],
+    };
+  }, {});
+}
+
 export function doesNotExist(value) {
   if (value === undefined || value === null) {
     return true;

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "prepare": "husky install"
   },
   "dependencies": {
+    "@citation-js/plugin-bibtex": "^0.7.2",
+    "@citation-js/plugin-ris": "^0.7.4",
     "@ckeditor/ckeditor5-react": "3.0.2",
     "@crello/react-lottie": "^0.0.11",
     "@elastic/apm-rum": "^5.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -121,6 +121,15 @@
     "@citation-js/name" "^0.4.2"
     moo "^0.5.1"
 
+"@citation-js/plugin-bibtex@^0.7.2":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@citation-js/plugin-bibtex/-/plugin-bibtex-0.7.2.tgz#0b87d86a0a0f9365aa690b7ab9d0383dd5f24605"
+  integrity sha512-QkgPfYbs1dierenxKWzIlPV7450Jci8bvZbcpjO3HQTfTaj15SV2C2AaeKhUotXZmTjm49AJQWHZtrNh+7YWjg==
+  dependencies:
+    "@citation-js/date" "^0.5.0"
+    "@citation-js/name" "^0.4.2"
+    moo "^0.5.1"
+
 "@citation-js/plugin-csl@0.6.8", "@citation-js/plugin-csl@^0.6.8":
   version "0.6.8"
   resolved "https://registry.yarnpkg.com/@citation-js/plugin-csl/-/plugin-csl-0.6.8.tgz#351454848e10113619546dd2eaf1124ac714ec26"
@@ -140,6 +149,14 @@
   version "0.6.8"
   resolved "https://registry.yarnpkg.com/@citation-js/plugin-ris/-/plugin-ris-0.6.8.tgz#a32de155dfa1fd4704b159937364db14a4c44a2c"
   integrity sha512-pDHdOjdrn25riXEwF3XK1fcU2o5/lxV2vbK+CxiFCiV2C2bRtNJRBN/97xIkHBWuqI5mr8ts93b3ijHvp3576Q==
+  dependencies:
+    "@citation-js/date" "^0.5.0"
+    "@citation-js/name" "^0.4.2"
+
+"@citation-js/plugin-ris@^0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@citation-js/plugin-ris/-/plugin-ris-0.7.4.tgz#b2c013ccc51a4a5f657ab1101bc07b54335a8438"
+  integrity sha512-8tqZPPiQ0XggHZCEvZSF4ssAi14xDzJo16hnE4xIuL/+Xk8WSbohscHaeroZLYpzkIZa+Qzq3o8r0g50H2hXTg==
   dependencies:
     "@citation-js/date" "^0.5.0"
     "@citation-js/name" "^0.4.2"


### PR DESCRIPTION
Add support for exporting references as BibTeX and RIS.

I also made a small change to `<QuickModal>` since the button colouring/styling didn't match the rest of our UI and it was bothering me.

### Screenshots

Updated UI for APA to include scrolling section for long reference lists.
<img width="600" alt="Screenshot 2023-11-20 at 8 56 30 AM" src="https://github.com/ResearchHub/researchhub-web/assets/16143968/e2b5f43a-4f92-42ee-a4cc-f6239411cc0c">

Exporting BibTeX or RIS directly opens save window.
<img width="600" alt="Screenshot 2023-11-20 at 8 56 54 AM" src="https://github.com/ResearchHub/researchhub-web/assets/16143968/069366ae-1404-4110-baff-619fe4005cf1">

