### PR TITLE
Fix bug where abstract couldn't be updated in paper page

### DIFF
--- a/components/Paper/abstract/PaperPageAbstractSection.tsx
+++ b/components/Paper/abstract/PaperPageAbstractSection.tsx
@@ -149,7 +149,6 @@ export default function PaperPageAbstractSection({
                       /* NOTE: Manually overriding legacy "abstract" field since it's being used as a preview text in home feed
                       All proceeding updates make changes to abstract_src */
                       id: paper.id,
-                      hubs: paper?.hubs.map((hub) => hub.id),
                       abstract_src: abstractSrc,
                       abstract: htmlStringToPlainString(abstractSrc, 2000),
                       abstract_src_type: "CK_EDITOR",


### PR DESCRIPTION
There was a runtime bug where `paper.hubs` was undefined, so trying to call `.map` threw an error.

After looking into it, it doesn't seem like we need to pass `hubs` in the request body (correct me if I'm wrong).

I tried updating abstracts on papers with and without hubs and the request works successfully, and hubs remain unchanged.