### PR TITLE
Hide pagination when searching hubs & update remaining Twitter logos

### DIFF
--- a/components/Home/sidebar/RootLeftSidebar.tsx
+++ b/components/Home/sidebar/RootLeftSidebar.tsx
@@ -10,7 +10,7 @@ import {
 import {
   faMedium,
   faDiscord,
-  faTwitter,
+  faXTwitter,
 } from "@fortawesome/free-brands-svg-icons";
 import { faChartSimple } from "@fortawesome/pro-regular-svg-icons";
 import { faBook } from "@fortawesome/pro-duotone-svg-icons";
@@ -447,11 +447,11 @@ function RootLeftSidebar({
           <div className={css(styles.footer)}>
             <div className={formattedFooterItemsButtonRow}>
               <ALink
-                href="https://twitter.com/researchhub"
+                href="https://x.com/researchhub"
                 overrideStyle={styles.leftSidebarFooterIcon}
                 target="__blank"
               >
-                {<FontAwesomeIcon icon={faTwitter}></FontAwesomeIcon>}
+                {<FontAwesomeIcon icon={faXTwitter}></FontAwesomeIcon>}
               </ALink>
               <ALink
                 href="https://discord.com/invite/ZcCYgcnUp5"

--- a/components/Home/sidebar/RootLeftSidebarSlider.tsx
+++ b/components/Home/sidebar/RootLeftSidebarSlider.tsx
@@ -1,7 +1,9 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faMedium } from "@fortawesome/free-brands-svg-icons";
-import { faDiscord } from "@fortawesome/free-brands-svg-icons";
-import { faTwitter } from "@fortawesome/free-brands-svg-icons";
+import {
+  faMedium,
+  faDiscord,
+  faXTwitter,
+} from "@fortawesome/free-brands-svg-icons";
 import { AuthActions } from "~/redux/auth";
 import { breakpoints } from "~/config/themes/screen";
 import { connect } from "react-redux";
@@ -115,11 +117,11 @@ function RootLeftSidebarSlider({
             style={{ marginLeft: "-4px !important" }}
           >
             <ALink
-              href="https://twitter.com/researchhub"
+              href="https://x.com/researchhub"
               overrideStyle={styles.leftSidebarSliderFooterIcon}
               target="__blank"
             >
-              {<FontAwesomeIcon icon={faTwitter}></FontAwesomeIcon>}
+              {<FontAwesomeIcon icon={faXTwitter}></FontAwesomeIcon>}
             </ALink>
             <ALink
               href="https://discord.com/invite/ZcCYgcnUp5"

--- a/components/Paper/Tabs/DiscussionTab.js
+++ b/components/Paper/Tabs/DiscussionTab.js
@@ -1,5 +1,5 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faTwitter } from "@fortawesome/free-brands-svg-icons";
+import { faXTwitter } from "@fortawesome/free-brands-svg-icons";
 import { Fragment, useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import { connect } from "react-redux";
@@ -356,7 +356,7 @@ const DiscussionTab = (props) => {
               : showTwitterComments && (
                   <span className={css(styles.box, styles.emptyStateBox)}>
                     <span className={css(styles.icon, styles.twitterIcon)}>
-                      {<FontAwesomeIcon icon={faTwitter}></FontAwesomeIcon>}
+                      {<FontAwesomeIcon icon={faXTwitter}></FontAwesomeIcon>}
                     </span>
                     <h3 className={css(styles.noSummaryTitle)}>
                       There are no tweets {mobileView && "\n"}for this paper

--- a/components/ShareDropdown.tsx
+++ b/components/ShareDropdown.tsx
@@ -1,6 +1,6 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faLinkedin } from "@fortawesome/free-brands-svg-icons";
-import { faTwitter } from "@fortawesome/free-brands-svg-icons";
+import { faXTwitter } from "@fortawesome/free-brands-svg-icons";
 import { css, StyleSheet } from "aphrodite";
 import { useState, useRef, useEffect } from "react";
 import colors from "~/config/themes/colors";
@@ -13,9 +13,9 @@ type Args = {
 const ShareDropdown = ({ handleClick, children }: Args) => {
   const options = [
     {
-      label: "Twitter",
+      label: "X / Twitter",
       value: "twitter",
-      icon: <FontAwesomeIcon icon={faTwitter}></FontAwesomeIcon>,
+      icon: <FontAwesomeIcon icon={faXTwitter}></FontAwesomeIcon>,
     },
     {
       label: "LinkedIn",

--- a/components/VoteWidget.js
+++ b/components/VoteWidget.js
@@ -26,7 +26,7 @@ import { breakpoints } from "~/config/themes/screen";
 import { faDown, faUp } from "@fortawesome/pro-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { voteWidgetIcons } from "~/config/themes/icons";
-import { faTwitter, faXTwitter } from "@fortawesome/free-brands-svg-icons";
+import { faXTwitter } from "@fortawesome/free-brands-svg-icons";
 import IconButton from "./Icons/IconButton";
 
 const VoteWidget = (props) => {

--- a/config/themes/iconsToModify.js
+++ b/config/themes/iconsToModify.js
@@ -71,7 +71,7 @@ import {
   faMedium,
   faReddit,
   faSlack,
-  faTwitter,
+  faXTwitter,
 } from "@fortawesome/free-brands-svg-icons";
 import {
   faArrowToBottom,
@@ -344,7 +344,7 @@ library.add(
   faTimesCircle,
   faTrashAlt,
   faTrophy,
-  faTwitter,
+  faXTwitter,
   faUnderline,
   faUndo,
   faUp,

--- a/pages/footer.js
+++ b/pages/footer.js
@@ -1,9 +1,11 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faGithub } from "@fortawesome/free-brands-svg-icons";
-import { faReddit } from "@fortawesome/free-brands-svg-icons";
-import { faTwitter } from "@fortawesome/free-brands-svg-icons";
-import { faDiscord } from "@fortawesome/free-brands-svg-icons";
-import { faMedium } from "@fortawesome/free-brands-svg-icons";
+import {
+  faGithub,
+  faReddit,
+  faXTwitter,
+  faDiscord,
+  faMedium,
+} from "@fortawesome/free-brands-svg-icons";
 import { Component } from "react";
 
 // NPM Modules
@@ -105,12 +107,12 @@ class Footer extends Component {
             <a
               target="_blank"
               className={css(styles.link)}
-              href="https://twitter.com/researchhub"
+              href="https://x.com/researchhub"
               rel="noreferrer noopener"
             >
               <div className={css(styles.social)}>
                 <span className={css(styles.logo)}>
-                  {<FontAwesomeIcon icon={faTwitter}></FontAwesomeIcon>}
+                  {<FontAwesomeIcon icon={faXTwitter}></FontAwesomeIcon>}
                 </span>
               </div>
             </a>

--- a/pages/hubs/index.tsx
+++ b/pages/hubs/index.tsx
@@ -256,28 +256,35 @@ const HubsPage: NextPage<Props> = ({
         </ReactPlaceholder>
         {noSuggestionsFound && <div>No hubs found.</div>}
       </div>
-      <div className={css(styles.pagination)}>
-        <Pagination
-          count={Math.ceil(count / 40)}
-          variant="outlined"
-          shape="rounded"
-          color="primary"
-          page={page}
-          // limiting boundary and sibling count reduces width of entire component,
-          // which is useful to prevent overflow/wrappping on mobile.
-          boundaryCount={isMobileScreen ? 1 : undefined}
-          siblingCount={isMobileScreen ? 0 : undefined}
-          onChange={(event, page) => {
-            const fetchHubs = async () => {
-              window.scrollTo({ top: 0 });
-              setPageHubs(page);
-              setPage(page);
-              // scroll to top
-            };
-            fetchHubs();
-          }}
-        />
-      </div>
+      {/*
+      Only show the Pagination component if user isn't searching.
+      We only show the first 25 search results (as of now), so pagination is not needed.
+      -> Permalink to 25 limit: https://github.com/ResearchHub/researchhub-backend/blob/e214e56b51ca707ae2d748830e298410f385b299/src/search/views/hub_suggester.py#L41
+      */}
+      {query.length <= 0 && (
+        <div className={css(styles.pagination)}>
+          <Pagination
+            count={Math.ceil(count / 40)}
+            variant="outlined"
+            shape="rounded"
+            color="primary"
+            page={page}
+            // limiting boundary and sibling count reduces width of entire component,
+            // which is useful to prevent overflow/wrappping on mobile.
+            boundaryCount={isMobileScreen ? 1 : undefined}
+            siblingCount={isMobileScreen ? 0 : undefined}
+            onChange={(event, page) => {
+              const fetchHubs = async () => {
+                window.scrollTo({ top: 0 });
+                setPageHubs(page);
+                setPage(page);
+                // scroll to top
+              };
+              fetchHubs();
+            }}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/pages/user/[authorId]/[tabName]/index.js
+++ b/pages/user/[authorId]/[tabName]/index.js
@@ -9,7 +9,7 @@ import {
 } from "@fortawesome/pro-solid-svg-icons";
 import {
   faFacebookF,
-  faTwitter,
+  faXTwitter,
   faLinkedin,
 } from "@fortawesome/free-brands-svg-icons";
 import {
@@ -88,7 +88,7 @@ const SECTIONS = {
   description: "description",
   facebook: "facebook",
   linkedin: "linkedin",
-  twitter: "twitter",
+  twitter: "x / twitter",
   picture: "picture",
 };
 
@@ -104,7 +104,7 @@ function AuthorPage(props) {
   // User External Links
   const [editFacebook, setEditFacebook] = useState(false);
   const [editLinkedin, setEditLinkedin] = useState(false);
-  const [editTwitter, setEditTwitter] = useState(false);
+  const [editXTwitter, setEditXTwitter] = useState(false);
 
   // User Profile Update
   const [avatarUploadIsOpen, setAvatarUploadIsOpen] = useState(false);
@@ -144,7 +144,7 @@ function AuthorPage(props) {
 
   const facebookRef = useRef();
   const linkedinRef = useRef();
-  const twitterRef = useRef();
+  const xTwitterRef = useRef();
 
   useEffect(() => {
     document.addEventListener("mousedown", handleOutsideClick);
@@ -336,8 +336,8 @@ function AuthorPage(props) {
     if (facebookRef.current && !facebookRef.current.contains(e.target)) {
       setEditFacebook(false);
     }
-    if (twitterRef.current && !twitterRef.current.contains(e.target)) {
-      setEditTwitter(false);
+    if (xTwitterRef.current && !xTwitterRef.current.contains(e.target)) {
+      setEditXTwitter(false);
     }
     if (linkedinRef.current && !linkedinRef.current.contains(e.target)) {
       setEditLinkedin(false);
@@ -485,7 +485,7 @@ function AuthorPage(props) {
 
     setEditFacebook(false);
     setEditLinkedin(false);
-    setEditTwitter(false);
+    setEditXTwitter(false);
 
     await dispatch(
       AuthorActions.saveAuthorChanges({ changes, authorId: author.id })
@@ -694,13 +694,13 @@ function AuthorPage(props) {
     },
     {
       link: safeGuardURL(author.twitter),
-      icon: <FontAwesomeIcon icon={faTwitter}></FontAwesomeIcon>,
-      nodeRef: twitterRef,
-      dataTip: "Set Twitter Profile",
-      onClick: () => setEditTwitter(true),
-      renderDropdown: () => editTwitter && renderSocialEdit(SECTIONS.twitter),
-      customStyles: styles.twitter,
-      isEditing: editTwitter,
+      icon: <FontAwesomeIcon icon={faXTwitter}></FontAwesomeIcon>,
+      nodeRef: xTwitterRef,
+      dataTip: "Set X / Twitter Profile",
+      onClick: () => setEditXTwitter(true),
+      renderDropdown: () => editXTwitter && renderSocialEdit(SECTIONS.twitter),
+      customStyles: styles.xTwitter,
+      isEditing: editXTwitter,
     },
     {
       link: safeGuardURL(author.facebook),
@@ -1438,8 +1438,8 @@ const styles = StyleSheet.create({
   linkedin: {
     background: "#0077B5",
   },
-  twitter: {
-    background: "#38A1F3",
+  xTwitter: {
+    background: "black",
   },
   facebook: {
     background: "#3B5998",


### PR DESCRIPTION
Hide pagination when searching hubs.

Update remaining Twitter logos to X. (this was bothering me)
- Kept copy as "X / Twitter"  to limit confusion