### PR TITLE
Small FeedCard Update

### DIFF
--- a/components/Author/Tabs/FeedCard.tsx
+++ b/components/Author/Tabs/FeedCard.tsx
@@ -131,6 +131,7 @@ function FeedCard({
   first_preview,
   type,
   document,
+  documentFilter,
   formattedDocLabel,
   formattedDocType,
   handleClick,
@@ -272,15 +273,8 @@ function FeedCard({
   const user = uploaded_by || created_by;
   const cardTitle = getTitle();
   const cardBody = getBody();
-  let bountyAmount = 0;
-  let hasActiveBounty = false;
-  bounties &&
-    bounties.forEach((bounty) => {
-      bountyAmount += bounty.amount;
-      if (!bounty.isExpiredOrClosed) {
-        hasActiveBounty = true;
-      }
-    });
+  let bountyAmount = documentFilter.bounty_total_amount;
+  let hasActiveBounty = documentFilter.bounty_open;
 
   return (
     <div

--- a/components/Author/Tabs/FeedCard.tsx
+++ b/components/Author/Tabs/FeedCard.tsx
@@ -70,7 +70,6 @@ const DocumentViewer = dynamic(
 
 export type FeedCardProps = {
   abstract: string;
-  boost_amount: number;
   bounties: Bounty[];
   created_by: any;
   document: any;
@@ -121,7 +120,6 @@ const documentIcons = {
 
 function FeedCard({
   abstract,
-  boost_amount: boostAmount,
   bounties,
   created_by,
   created_date,

--- a/components/UnifiedDocFeed/utils/getDocumentCard.tsx
+++ b/components/UnifiedDocFeed/utils/getDocumentCard.tsx
@@ -45,6 +45,7 @@ export function getDocumentCard({
           twitterScore={targetDoc.twitter_score}
           key={`${formattedDocType}-${docID}-${arrIndex}`}
           paper={uniDoc.documents}
+          hubs={uniDoc.hubs}
           vote={uniDoc.user_vote}
           score={uniDoc.score}
           featured={uniDoc.featured}

--- a/components/UnifiedDocFeed/utils/getDocumentCard.tsx
+++ b/components/UnifiedDocFeed/utils/getDocumentCard.tsx
@@ -39,6 +39,7 @@ export function getDocumentCard({
         <FeedCard
           {...targetDoc}
           document={targetDoc}
+          documentFilter={uniDoc.document_filter}
           formattedDocType={formattedDocType}
           formattedDocLabel={formattedDocLabel}
           index={arrIndex}

--- a/components/UnifiedDocFeed/utils/getDocumentCard.tsx
+++ b/components/UnifiedDocFeed/utils/getDocumentCard.tsx
@@ -52,7 +52,7 @@ export function getDocumentCard({
           featured={uniDoc.featured}
           reviews={uniDoc.reviews}
           bounties={bounties}
-          hasAcceptedAnswer={targetDoc.has_accepted_answer}
+          hasAcceptedAnswer={uniDoc.document_filter.answered}
           voteCallback={(arrIndex: number, currPaper: any): void => {
             const [currUniDoc, newUniDocs] = [
               { ...uniDoc },


### PR DESCRIPTION
Removing used `boost_amount`
Using hubs from unified document instead of document
Bounty logic now uses bounty information from `document_filter`