### PR TITLE
Multiple UI improvements and fixes to Replication Voting

### DIFF
--- a/components/Document/pages/DocumentReplicationMarketPage.tsx
+++ b/components/Document/pages/DocumentReplicationMarketPage.tsx
@@ -49,7 +49,7 @@ const DocumentReplicationMarketPage: NextPage<Args> = ({
   const [viewerWidth, setViewerWidth] = useState<number | undefined>(
     config.width
   );
-  const [tab, setTab] = useState<"COMMENTS" | "VOTES">("COMMENTS");
+  const [tab, setTab] = useState<"COMMENTS" | "VOTES">("VOTES");
   const { revalidateDocument } = useCacheControl();
 
   const [documentMetadata, setDocumentMetadata] = useDocumentMetadata({
@@ -284,17 +284,17 @@ const DocumentReplicationMarketPage: NextPage<Args> = ({
               <HorizontalTabBar
                 tabs={[
                   {
-                    label: "Comments",
-                    value: "COMMENTS",
-                    isSelected: tab === "COMMENTS",
-                    pillContent: commentCount > 0 ? commentCount : undefined,
-                  },
-                  {
                     label: "Votes",
                     value: "VOTES",
                     isSelected: tab === "VOTES",
                     pillContent:
                       market.votes.total > 0 ? market.votes.total : undefined,
+                  },
+                  {
+                    label: "Comments",
+                    value: "COMMENTS",
+                    isSelected: tab === "COMMENTS",
+                    pillContent: commentCount > 0 ? commentCount : undefined,
                   },
                 ]}
                 onClick={(tab) => setTab(tab.value as "COMMENTS" | "VOTES")}

--- a/components/PredictionMarket/PredictionMarketVoteForm.tsx
+++ b/components/PredictionMarket/PredictionMarketVoteForm.tsx
@@ -47,7 +47,11 @@ const PredictionMarketVoteForm = ({
   );
 
   useEffect(() => {
-    const vote = allVotes.find((v) => v.createdBy.id === currentUser?.id);
+    const vote = allVotes.find(
+      (v) =>
+        v.createdBy.id === currentUser?.id ||
+        v.createdBy.authorProfile?.id === currentUser?.authorProfile?.id
+    );
     if (vote) {
       setPrevVote(vote);
       setVote(vote.vote);
@@ -55,7 +59,7 @@ const PredictionMarketVoteForm = ({
       setPrevVote(null);
       setVote(null);
     }
-  }, [allVotes]);
+  }, [allVotes, currentUser]);
 
   const handleSubmit = async (vote: "YES" | "NO") => {
     if (vote === null || vote === prevVote?.vote) {

--- a/components/PredictionMarket/PredictionMarketVoteForm.tsx
+++ b/components/PredictionMarket/PredictionMarketVoteForm.tsx
@@ -3,7 +3,6 @@ import ReactTooltip from "react-tooltip";
 import Button from "../Form/Button";
 import colors from "../../config/themes/colors";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faCircleInfo } from "@fortawesome/pro-regular-svg-icons";
 import { createVote } from "./api/votes";
 import { ID, parseUser } from "~/config/types/root_types";
 import { PredictionMarketDetails, PredictionMarketVote } from "./lib/types";
@@ -114,16 +113,9 @@ const PredictionMarketVoteForm = ({
         <div className={css(styles.title)}>
           Do you think this paper is replicable?
         </div>
-        <div
-          data-tip="Do you think an independent researcher/lab can produce results that confirm the conclusion(s) of the paper."
-          data-for="link-tooltip"
-          className={css(styles.tooltipIcon)}
-        >
-          <FontAwesomeIcon
-            icon={faCircleInfo}
-            color={colors.MEDIUM_GREY2(1)}
-            fontSize={12}
-          />
+        <div className={css(styles.subtitle)}>
+          Can an independent researcher/lab produce results that confirm the
+          conclusion(s) of the paper?
         </div>
       </div>
       {isCurrentUserAuthor && (
@@ -223,14 +215,20 @@ const styles = StyleSheet.create({
   },
   header: {
     display: "flex",
-    flexDirection: "row",
-    alignItems: "center",
+    flexDirection: "column",
+    alignItems: "flex-start",
     marginBottom: 16,
   },
   title: {
     fontSize: 14,
     fontWeight: 500,
-    paddingRight: 6,
+    paddingBottom: 6,
+  },
+  subtitle: {
+    fontSize: 12,
+    fontWeight: 400,
+    lineHeight: 1.4,
+    color: colors.MEDIUM_GREY2(1),
   },
   cantVoteText: {
     fontSize: 14,


### PR DESCRIPTION
Move votes tab first and move tooltip text to subtitle.

<img width="1033" alt="Screenshot 2023-12-01 at 9 44 31 AM" src="https://github.com/ResearchHub/researchhub-web/assets/16143968/953e3349-1919-4526-bba1-ba82ea3768fc">
<br /> <br />
Also added more robust logic to associate votes with current user. Since it wasn't working when doing votes in prod.
