### PR TITLE
Get hyperlinks and anchors working with PDFs

### DIFF
--- a/components/Document/DocumentViewer.tsx
+++ b/components/Document/DocumentViewer.tsx
@@ -104,9 +104,6 @@ const DocumentViewer = ({
   const [viewerContext, setViewerContext] = useState<ViewerContext>(
     ViewerContext.GENERIC
   );
-  const [numPagesToPreload, setNumPagesToPreload] = useState<number>(
-    config.numPdfPagesToPreload
-  );
   const [lastPageRendered, setLastPageRendered] = useState<Page>({
     pageNumber: 0,
   });
@@ -287,35 +284,6 @@ const DocumentViewer = ({
     }
   }
 
-  function onCommentsFetched({
-    threads,
-    comments,
-    urlPosition,
-  }: {
-    threads: { [threadId: string]: CommentThreadGroup };
-    comments: CommentType[];
-    urlPosition: any;
-  }) {
-    let furthestPageToPreload = config.numPdfPagesToPreload;
-
-    if (
-      urlPosition?.pageNumber &&
-      urlPosition?.pageNumber > furthestPageToPreload
-    ) {
-      furthestPageToPreload = urlPosition?.pageNumber;
-    }
-
-    comments.forEach((comment) => {
-      const commentPageNum = comment?.thread?.anchor?.pageNumber || 1;
-
-      if (commentPageNum > furthestPageToPreload) {
-        furthestPageToPreload = commentPageNum;
-      }
-    });
-
-    setNumPagesToPreload(furthestPageToPreload);
-  }
-
   // TODO: Update this. Will probably need to create a DocumentViewer Context
   const actualContentWidth = isExpanded
     ? viewerWidth * fullScreenSelectedZoom
@@ -422,7 +390,6 @@ const DocumentViewer = ({
                     documentInstance={documentInstance}
                     citationInstance={citationInstance}
                     contentRef={contentRef}
-                    onFetch={onCommentsFetched}
                   />
                 )}
 
@@ -440,7 +407,11 @@ const DocumentViewer = ({
                         viewerWidth={actualContentWidth}
                         onLoadError={setHasLoadError}
                         onPageRender={setLastPageRendered}
-                        numPagesToPreload={numPagesToPreload}
+                        // This used to be programmatic (and not "all"),
+                        // but we wanted to give the user the ability to scroll to anchor links,
+                        // e.g. "some claim [1]", and clicking on [1] would scroll to the reference at the end.
+                        // and the simplest way to enable that was to preload all pages.
+                        numPagesToPreload="all"
                         showWhenLoading={
                           <div style={{ padding: 20 }}>
                             <DocumentPlaceholder />

--- a/components/Document/lib/PDFViewer/_PDFViewer.tsx
+++ b/components/Document/lib/PDFViewer/_PDFViewer.tsx
@@ -73,6 +73,121 @@ const PDFViewer = ({
   const observer = useRef<HTMLDivElement>(null);
   const eventBus = new EventBus();
 
+  // Store destinations for internal links (e.g. anchors)
+  const internalLinkDestinations = useRef({});
+  // Used to specify a target page that we should scroll to
+  const [scrollTarget, setScrollTarget] = useState<{
+    page: number;
+    x?: number;
+    y?: number;
+  } | null>(null);
+
+  useEffect(() => {
+    // If there is a scrollTarget, scroll to it.
+    // We do scrolling because we have existing logic to load additional pages
+    // when we scroll to the bottom of the page.
+    if (!scrollTarget) return;
+
+    const { page } = scrollTarget;
+
+    if (page !== undefined && !renderedPages[page]) {
+      // Scroll to the bottom of the last rendered page
+      const lastPageRendered = Object.keys(renderedPages).length;
+      if (lastPageRendered < page) {
+        renderedPages[lastPageRendered]?.pageContainer.scrollIntoView({
+          behavior: "smooth",
+        });
+      } else if (lastPageRendered === page) {
+        // Target page is now rendered, perform scrolling logic
+        const pageContainer = renderedPages[page]?.pageContainer;
+        pageContainer.scrollIntoView({ behavior: "smooth" });
+
+        // Reset scrollTarget
+        setScrollTarget(null);
+      }
+    } else {
+      // Target page is already rendered, perform your scrolling logic
+      const pageContainer = renderedPages[page]?.pageContainer;
+      pageContainer.scrollIntoView({ behavior: "smooth" });
+
+      // Reset scrollTarget
+      setScrollTarget(null);
+    }
+  }, [renderedPages, scrollTarget]);
+
+  const navigateToDestination = useCallback(
+    async (destination) => {
+      if (destination === null || destination === undefined) return;
+
+      if (typeof destination === "number") {
+        // Simple case: destination is a page number
+        const targetPageNumber = destination;
+        if (targetPageNumber >= 1 && targetPageNumber <= numPages) {
+          // Logic to scroll to the top of the target page
+          const pageToScroll = renderedPages[targetPageNumber].pageContainer;
+          if (pageToScroll) {
+            pageToScroll.scrollIntoView({ behavior: "smooth" });
+          } else {
+            // We haven't rendered the target page yet, so we need to load it.
+            // Set is as the scroll target so we can iteratively scroll to it.
+            setScrollTarget({
+              page: targetPageNumber,
+            });
+          }
+        }
+      } else if (Array.isArray(destination)) {
+        // desitation is an array of page/coordinate details.
+        // e.g. [ { num: 1, gen: 0 }, { name: 'XYZ' }, 0, 841.89, null ]
+        const objectNumber = destination[0].num;
+        const generationNumber = destination[0].gen;
+        try {
+          const pageNumber =
+            (await pdfDocument.getPageIndex({
+              num: objectNumber,
+              gen: generationNumber,
+            })) + 1; // getPageIndex is zero-based
+          if (pageNumber >= 1 && pageNumber <= numPages) {
+            const pageContainer = renderedPages[pageNumber]?.pageContainer;
+            if (pageContainer) {
+              pageContainer.scrollIntoView({ behavior: "smooth" });
+            } else {
+              // We haven't rendered the target page yet, so we need to load it.
+              // Set is as the scroll target so we can iteratively scroll to it.
+              setScrollTarget({
+                page: pageNumber,
+              });
+            }
+          }
+        } catch (error) {
+          console.log("error navigating to destination", error);
+        }
+      } else {
+        // it's a named destination that we need to look up in the document
+        navigateToNamedDestination(destination);
+      }
+    },
+    [numPages, renderedPages]
+  );
+
+  const navigateToNamedDestination = useCallback(
+    async (namedDestination) => {
+      try {
+        const resolvedDestination = await pdfDocument.getDestination(
+          namedDestination
+        );
+        if (resolvedDestination) {
+          // resolvedDestination is an array of page/coordinate details.
+          // e.g. [ { num: 1, gen: 0 }, { name: 'XYZ' }, 0, 841.89, null ]
+          // So we can handle it in navigateToDestination
+          navigateToDestination(resolvedDestination);
+        }
+      } catch (error) {
+        console.log("error navigating to named destination", error);
+      }
+    },
+    [pdfDocument, navigateToDestination]
+  );
+
   const loadPage = useCallback(
     async (pageNumber) => {
       setPagesLoading((prevPagesLoading) => {
@@ -102,13 +217,49 @@ const PDFViewer = ({
       pdfPageView.setPdfPage(page);
       await pdfPageView.draw();
 
+      // Setup links to internal destinations (e.g. link to a specific citation or figure/table)
+      const annotations = await page.getAnnotations();
+      const internalLinks = annotations.filter(
+        (ann) => ann.subtype === "Link" && ann.url === undefined
+      );
+      internalLinks.forEach((link, index) => {
+        const destination = link.dest; // 'dest' is the PDF.js property for internal destinations
+        internalLinkDestinations.current[
+          `internal-link-${pageNumber}-${index}`
+        ] = destination;
+      });
+
       const pageDiv = pageContainer.querySelector(".page") as HTMLDivElement;
       const annotationsDiv = pageContainer.querySelector(
         ".annotationLayer"
       ) as HTMLDivElement;
 
       if (pageDiv) pageDiv.style.margin = "0 auto";
-      if (annotationsDiv) annotationsDiv.style.display = "none";
+      if (annotationsDiv) {
+        // if we wanted to hide annotations, we'd set display to "none"
+        annotationsDiv.style.display = "block";
+        // we unset left, since the default is 0 but that results in annotations
+        // being rendered further to the left than the page content.
+        annotationsDiv.style.left = "unset";
+
+        // Setup internal and external links
+        const links = annotationsDiv.getElementsByTagName("a");
+        for (let index = 0; index < links.length; index++) {
+          const link = links[index];
+          if (link.href === "#" || link.href.endsWith("#")) {
+            // it's an internal link, so we want to setup custom scrolling to whatever anchor it's pointing to
+            const linkKey = `internal-link-${pageNumber}-${index}`;
+            link.addEventListener("click", (event) => {
+              event.preventDefault();
+              const destination = internalLinkDestinations.current[linkKey];
+              navigateToDestination(destination);
+            });
+          } else {
+            // it's an external link, so we want to open it in a new tab
+            link.target = "_blank";
+          }
+        }
+      }
 
       const textLayerDiv = pageContainer.querySelector(
         ".textLayer"

--- a/components/Document/lib/config.ts
+++ b/components/Document/lib/config.ts
@@ -5,7 +5,11 @@ const config = {
   background: "#FCFCFC",
   controlsWidth: 260,
   border: globalColors.GREY_LINE(1.0),
-  numPdfPagesToPreload: 3,
+  // This used to be 3 (and not "all"),
+  // but we wanted to give the user the ability to scroll to anchor links,
+  // e.g. "some claim [1]", and clicking on [1] would scroll to the reference at the end.
+  // and the simplest way to enable that was to preload all pages.
+  numPdfPagesToPreload: "all",
 };
 
 export default config;


### PR DESCRIPTION
Enabled annotations on PDFs and got hyperlinks and anchor links working.
- Hyperlinks open the link in a new tab
- Anchor links scroll to the page where the reference is

Tested viewers on both paper page and reference manager:
- Desktop (Brave, Chrome, Safari, Firefox)
- Mobile (Brave)

Checked bundle/build sizes and didn't see any increase.