### PR TITLE
Improve how we handle copyrighted PDFs

### DIFF
--- a/components/Document/PaperMetadataForm.tsx
+++ b/components/Document/PaperMetadataForm.tsx
@@ -11,7 +11,90 @@ import updatePaperMetadataAPI from "./api/updatePaperMetadataAPI";
 import colors from "~/config/themes/colors";
 import HubSelectDropdown from "../Hubs/HubSelectDropdown";
 import { ClipLoader } from "react-spinners";
+import { components } from "react-select";
+import useCurrentUser from "~/config/hooks/useCurrentUser";
+import FormSelect from "../Form/FormSelect";
 const { setMessage, showMessage } = MessageActions;
+
+// These options match the OpenAlex types: https://api.openalex.org/works?group_by=primary_location.license:include_unknown
+const LICENSE_OPTIONS = [
+  {
+    label: "Unknown",
+    value: "unknown",
+    description: "The license status of this paper is unclear or not provided.",
+  },
+  {
+    label: "CC BY",
+    value: "cc-by",
+    description:
+      "Allows others to distribute, remix, adapt, and build upon the work, even commercially, as long as they credit the author for the original creation.",
+  },
+  {
+    label: "CC BY-NC-ND",
+    value: "cc-by-nc-nd",
+    description:
+      "Allows others to download the works and share them with others as long as they credit the author, but they can't change them in any way or use them commercially.",
+  },
+  {
+    label: "CC BY-NC",
+    value: "cc-by-nc",
+    description:
+      "Allows others to remix, tweak, and build upon the work non-commercially, and although their new works must also acknowledge the author and be non-commercial, they don't have to license their derivative works on the same terms.",
+  },
+  {
+    label: "CC BY-NC-SA",
+    value: "cc-by-nc-sa",
+    description:
+      "Allows others to remix, tweak, and build upon the work non-commercially, as long as they credit the author and license their new creations under the identical terms.",
+  },
+  {
+    label: "CC BY-SA",
+    value: "cc-by-sa",
+    description:
+      "Allows others to remix, tweak, and build upon the work even for commercial purposes, as long as they credit the author and license their new creations under the identical terms.",
+  },
+  {
+    label: "CC BY-ND",
+    value: "cc-by-nd",
+    description:
+      "Allows for redistribution, commercial and non-commercial, as long as the work is passed along unchanged and in whole, with credit to the author.",
+  },
+  {
+    label: "Publisher-Specific Open-Access",
+    value: "publisher-specific-oa",
+    description:
+      "Open access license defined by the publisher, which may include specific restrictions and conditions.",
+  },
+  {
+    label: "Publisher-Specific or Author Manuscript",
+    value: "publisher-specific, author manuscript",
+    description:
+      "Includes publisher-specific licenses or papers that are author manuscripts, possibly with different usage rights.",
+  },
+  {
+    label: "CC0 (Public Domain)",
+    value: "public-domain",
+    description:
+      "Indicates that the author has waived all copyright and related rights, placing the work in the public domain.",
+  },
+  {
+    label: "Other Open-Access",
+    value: "other-oa",
+    description:
+      "Open access license not covered by other categories, may include various less common open-access types.",
+  },
+];
+
+const LicenseOptionWithDescription: React.FC<any> = (props) => {
+  return (
+    <components.Option {...props}>
+      <div>{props.data.label}</div>
+      <small style={{ opacity: 0.5, textTransform: "none" }}>
+        {props.data.description}
+      </small>
+    </components.Option>
+  );
+};
 
 interface FormProps {
   paper: Paper;
@@ -20,11 +103,16 @@ interface FormProps {
 }
 
 const PaperMetadataForm = ({ paper, onUpdate, metadata }: FormProps) => {
+  const user = useCurrentUser();
   const [fields, setFields] = useState({
     doi: paper.doi || "",
     publishedDate: formatDateStandard(paper.publishedDate, "MM/DD/YYYY"),
     title: paper.title || "",
     hubs: metadata.hubs,
+    pdfLicense:
+      LICENSE_OPTIONS.find(
+        (l) => l.value === paper.license || l.value === paper.raw.pdf_license
+      ) || LICENSE_OPTIONS[0],
   });
 
   const [saveInProgress, setSaveInProgress] = useState(false);
@@ -62,6 +150,11 @@ const PaperMetadataForm = ({ paper, onUpdate, metadata }: FormProps) => {
       return;
     }
 
+    let pdfLicense: string | undefined = fields.pdfLicense?.value;
+    if (pdfLicense === "unknown") {
+      pdfLicense = undefined;
+    }
+
     setSaveInProgress(true);
     updatePaperMetadataAPI({
       id: paper.id,
@@ -69,6 +162,7 @@ const PaperMetadataForm = ({ paper, onUpdate, metadata }: FormProps) => {
       doi: fields.doi,
       publishedDate: fields.publishedDate,
       hubs: fields.hubs.map((h) => h.id),
+      pdfLicense: pdfLicense,
     })
       .then(() => {
         onUpdate &&
@@ -77,6 +171,7 @@ const PaperMetadataForm = ({ paper, onUpdate, metadata }: FormProps) => {
             publishedDate: fields.publishedDate,
             doi: fields.doi,
             hubs: fields.hubs,
+            pdfLicense: pdfLicense,
           });
         dispatch(setMessage("Paper updated"));
 
@@ -148,6 +243,27 @@ const PaperMetadataForm = ({ paper, onUpdate, metadata }: FormProps) => {
           onChange={handleChange}
         />
       </div>
+      {user?.moderator && (
+        <div style={{ display: "flex" }}>
+          <FormSelect
+            containerStyle={formStyles.container}
+            id="pdfLicense"
+            label="PDF License"
+            reactStyles={{}}
+            inputStyle={formStyles.inputStyle}
+            reactSelect={{ styles: {} }}
+            onChange={(name, value) => {
+              handleChange("pdfLicense", value);
+            }}
+            selectComponents={{
+              Option: LicenseOptionWithDescription,
+            }}
+            options={LICENSE_OPTIONS}
+            value={fields.pdfLicense}
+          />
+          <div />
+        </div>
+      )}
 
       <div style={{ display: "flex", justifyContent: "flex-end" }}>
         <Button disabled={saveInProgress} onClick={handleSubmit} type="submit">

--- a/components/Document/PaperMetadataForm.tsx
+++ b/components/Document/PaperMetadataForm.tsx
@@ -14,76 +14,8 @@ import { ClipLoader } from "react-spinners";
 import { components } from "react-select";
 import useCurrentUser from "~/config/hooks/useCurrentUser";
 import FormSelect from "../Form/FormSelect";
+import { LICENSE_OPTIONS } from "~/config/types/licenseOptions";
 const { setMessage, showMessage } = MessageActions;
-
-// These options match the OpenAlex types: https://api.openalex.org/works?group_by=primary_location.license:include_unknown
-const LICENSE_OPTIONS = [
-  {
-    label: "Unknown",
-    value: "unknown",
-    description: "The license status of this paper is unclear or not provided.",
-  },
-  {
-    label: "CC BY",
-    value: "cc-by",
-    description:
-      "Allows others to distribute, remix, adapt, and build upon the work, even commercially, as long as they credit the author for the original creation.",
-  },
-  {
-    label: "CC BY-NC-ND",
-    value: "cc-by-nc-nd",
-    description:
-      "Allows others to download the works and share them with others as long as they credit the author, but they can't change them in any way or use them commercially.",
-  },
-  {
-    label: "CC BY-NC",
-    value: "cc-by-nc",
-    description:
-      "Allows others to remix, tweak, and build upon the work non-commercially, and although their new works must also acknowledge the author and be non-commercial, they don't have to license their derivative works on the same terms.",
-  },
-  {
-    label: "CC BY-NC-SA",
-    value: "cc-by-nc-sa",
-    description:
-      "Allows others to remix, tweak, and build upon the work non-commercially, as long as they credit the author and license their new creations under the identical terms.",
-  },
-  {
-    label: "CC BY-SA",
-    value: "cc-by-sa",
-    description:
-      "Allows others to remix, tweak, and build upon the work even for commercial purposes, as long as they credit the author and license their new creations under the identical terms.",
-  },
-  {
-    label: "CC BY-ND",
-    value: "cc-by-nd",
-    description:
-      "Allows for redistribution, commercial and non-commercial, as long as the work is passed along unchanged and in whole, with credit to the author.",
-  },
-  {
-    label: "Publisher-Specific Open-Access",
-    value: "publisher-specific-oa",
-    description:
-      "Open access license defined by the publisher, which may include specific restrictions and conditions.",
-  },
-  {
-    label: "Publisher-Specific or Author Manuscript",
-    value: "publisher-specific, author manuscript",
-    description:
-      "Includes publisher-specific licenses or papers that are author manuscripts, possibly with different usage rights.",
-  },
-  {
-    label: "CC0 (Public Domain)",
-    value: "public-domain",
-    description:
-      "Indicates that the author has waived all copyright and related rights, placing the work in the public domain.",
-  },
-  {
-    label: "Other Open-Access",
-    value: "other-oa",
-    description:
-      "Open access license not covered by other categories, may include various less common open-access types.",
-  },
-];
 
 const LicenseOptionWithDescription: React.FC<any> = (props) => {
   return (
@@ -150,11 +82,6 @@ const PaperMetadataForm = ({ paper, onUpdate, metadata }: FormProps) => {
       return;
     }
 
-    let pdfLicense: string | undefined = fields.pdfLicense?.value;
-    if (pdfLicense === "unknown") {
-      pdfLicense = undefined;
-    }
-
     setSaveInProgress(true);
     updatePaperMetadataAPI({
       id: paper.id,
@@ -162,7 +89,7 @@ const PaperMetadataForm = ({ paper, onUpdate, metadata }: FormProps) => {
       doi: fields.doi,
       publishedDate: fields.publishedDate,
       hubs: fields.hubs.map((h) => h.id),
-      pdfLicense: pdfLicense,
+      pdfLicense: fields.pdfLicense?.value,
     })
       .then(() => {
         onUpdate &&
@@ -171,7 +98,7 @@ const PaperMetadataForm = ({ paper, onUpdate, metadata }: FormProps) => {
             publishedDate: fields.publishedDate,
             doi: fields.doi,
             hubs: fields.hubs,
-            pdfLicense: pdfLicense,
+            pdfLicense: fields.pdfLicense?.value,
           });
         dispatch(setMessage("Paper updated"));
 

--- a/components/Document/api/updatePaperMetadataAPI.ts
+++ b/components/Document/api/updatePaperMetadataAPI.ts
@@ -9,12 +9,14 @@ export const updatePaperMetadataAPI = async ({
   doi,
   publishedDate,
   hubs,
+  pdfLicense,
 }: {
   id: ID;
   title?: string;
   doi?: string;
   publishedDate?: string;
   hubs?: Array<ID>;
+  pdfLicense?: string;
 }) => {
   const url = generateApiUrl(`paper/${id}`);
   const response = await fetch(
@@ -27,6 +29,7 @@ export const updatePaperMetadataAPI = async ({
       ...(publishedDate && {
         paper_publish_date: dayjs(publishedDate).format("YYYY-MM-DD"),
       }),
+      ...(pdfLicense && { pdf_license: pdfLicense }),
     })
   ).then((res): any => Helpers.parseJSON(res));
 

--- a/components/Document/lib/types.ts
+++ b/components/Document/lib/types.ts
@@ -209,6 +209,7 @@ export const parsePaper = (raw: any): Paper => {
     abstractHtml: raw.abstract_src_markdown,
     type: "paper",
     apiDocumentType: "paper",
+    pdfCopyrightAllowsDisplay: Boolean(raw.pdf_copyright_allows_display),
     ...(raw.pdf_license && { license: raw.pdf_license }),
   };
 

--- a/components/LiveFeed/Contribution/ContributionEntry.tsx
+++ b/components/LiveFeed/Contribution/ContributionEntry.tsx
@@ -284,6 +284,7 @@ const styles = StyleSheet.create({
   actions: {
     marginTop: 5,
     display: "flex",
+    gap: 8,
   },
   documentLink: {
     fontWeight: 500,

--- a/components/LiveFeed/FlaggedContentDashboard.tsx
+++ b/components/LiveFeed/FlaggedContentDashboard.tsx
@@ -30,6 +30,7 @@ import LoadMoreButton from "../LoadMoreButton";
 import removeFlaggedContent from "./api/removeFlaggedContentAPI";
 import ContributionEntry from "./Contribution/ContributionEntry";
 import IconButton from "../Icons/IconButton";
+import removeFlaggedPaperPDFApi from "./api/removeFlaggedPaperPDFAPI";
 
 function FlaggedContentDashboard({
   setMessage,
@@ -245,6 +246,52 @@ function FlaggedContentDashboard({
           style: styles.flagAndRemove,
           isActive: appliedFilters.verdict === "OPEN",
         },
+        r.contentType.name === "paper"
+          ? {
+              html: (
+                <FlagButtonV2
+                  modalHeaderText="Flag and Remove PDF"
+                  flagIconOverride={styles.flagIcon}
+                  iconOverride={
+                    <FontAwesomeIcon icon={faTrash}></FontAwesomeIcon>
+                  }
+                  defaultReason={r.reason}
+                  successMsgText="Flagged PDF removed"
+                  errorMsgText="Failed to remove flagged PDF"
+                  subHeaderText="I am removing the paper's PDF because of:"
+                  primaryButtonLabel="Remove PDF"
+                  onSubmit={(
+                    verdict: KeyOf<typeof FLAG_REASON>,
+                    renderErrorMsg,
+                    renderSuccessMsg
+                  ) => {
+                    removeFlaggedPaperPDFApi({
+                      apiParams: {
+                        flagIds: [r.id],
+                        // @ts-ignore
+                        verdictChoice: verdict,
+                      },
+                      onError: renderErrorMsg,
+                      onSuccess: () => {
+                        renderSuccessMsg();
+                        setResults(results.filter((res) => res.id !== r.id));
+                        setNumNavInteractions(numNavInteractions - 1);
+                      },
+                    });
+                  }}
+                >
+                  <IconButton>
+                    <span style={{ color: colors.ORANGE_DARK() }}>
+                      Remove PDF Only
+                    </span>
+                  </IconButton>
+                </FlagButtonV2>
+              ),
+              label: "Remove PDF Only",
+              style: styles.flagAndRemove,
+              isActive: appliedFilters.verdict === "OPEN",
+            }
+          : undefined,
         {
           html: (
             <IconButton
@@ -282,7 +329,7 @@ function FlaggedContentDashboard({
           // style: styles.flagAndRemove,
           isActive: appliedFilters.verdict === "OPEN",
         },
-      ];
+      ].filter((a) => a);
 
       return (
         <div className={css(styles.result)} key={r.id}>

--- a/components/LiveFeed/api/removeFlaggedPaperPDFAPI.ts
+++ b/components/LiveFeed/api/removeFlaggedPaperPDFAPI.ts
@@ -1,0 +1,41 @@
+import { captureEvent } from "~/config/utils/events";
+import { FLAG_REASON } from "~/components/Flag/config/flag_constants";
+import { Helpers } from "@quantfive/js-web-config";
+import { ID, KeyOf } from "~/config/types/root_types";
+import API, { generateApiUrl } from "~/config/api";
+
+type APIParams = {
+  flagIds: Array<ID>;
+  verdictChoice?: KeyOf<typeof FLAG_REASON>;
+};
+
+type Args = {
+  apiParams: APIParams;
+  onSuccess: Function;
+  onError: Function;
+};
+
+export default function removeFlaggedPaperPDFApi({
+  apiParams,
+  onSuccess,
+  onError,
+}: Args): void {
+  const config = {
+    flag_ids: apiParams.flagIds,
+    ...(apiParams.verdictChoice && { verdict_choice: apiParams.verdictChoice }),
+  };
+
+  const url = generateApiUrl("audit/remove_flagged_paper_pdf");
+
+  fetch(url, API.POST_CONFIG(config))
+    .then(Helpers.checkStatus)
+    .then((response) => onSuccess(response))
+    .catch((error: Error) => {
+      captureEvent({
+        error,
+        msg: "Failed to remove flagged content",
+        data: { apiParams },
+      });
+      onError(error);
+    });
+}

--- a/components/Paper/Tabs/PaperTab.js
+++ b/components/Paper/Tabs/PaperTab.js
@@ -153,24 +153,27 @@ function PaperTab(props) {
         </div>
       );
     }
-    if (file) {
+    if (
+      !paper.pdf_copyright_allows_display ||
+      !paper.pdfCopyrightAllowsDisplay
+    ) {
+      return (
+        <div>
+          <p>
+            This paper's license is marked as closed access or non-commercial
+            and cannot be viewed on ResearchHub.{" "}
+            <ALink target="_blank" theme="solidPrimary" href={paper.url}>
+              Visit the paper's external site.
+            </ALink>
+          </p>
+        </div>
+      );
+    } else if (file) {
       const httpsUrl = convertHttpToHttps(file);
 
       return (
         <div className={css(styles.pdfFrame)}>
           <iframe src={httpsUrl} height={800} width={"100%"} loading="lazy" />
-        </div>
-      );
-    } else if (paper.oa_status && paper.oa_status === "closed") {
-      return (
-        <div>
-          <p>
-            This paper's license is marked as closed access and cannot be viewed
-            on ResearchHub.{" "}
-            <ALink target="_blank" theme="solidPrimary" href={paper.url}>
-              Visit the paper's external site.
-            </ALink>
-          </p>
         </div>
       );
     } else {

--- a/config/types/licenseOptions.ts
+++ b/config/types/licenseOptions.ts
@@ -1,0 +1,69 @@
+// These options match the OpenAlex types.
+// https://api.openalex.org/works?group_by=primary_location.license:include_unknown
+export const LICENSE_OPTIONS = [
+  {
+    label: "Unknown",
+    value: "unknown",
+    description: "The license status of this paper is unclear or not provided.",
+  },
+  {
+    label: "CC BY",
+    value: "cc-by",
+    description:
+      "Allows others to distribute, remix, adapt, and build upon the work, even commercially, as long as they credit the author for the original creation.",
+  },
+  {
+    label: "CC BY-NC-ND",
+    value: "cc-by-nc-nd",
+    description:
+      "Allows others to download the works and share them with others as long as they credit the author, but they can't change them in any way or use them commercially.",
+  },
+  {
+    label: "CC BY-NC",
+    value: "cc-by-nc",
+    description:
+      "Allows others to remix, tweak, and build upon the work non-commercially, and although their new works must also acknowledge the author and be non-commercial, they don't have to license their derivative works on the same terms.",
+  },
+  {
+    label: "CC BY-NC-SA",
+    value: "cc-by-nc-sa",
+    description:
+      "Allows others to remix, tweak, and build upon the work non-commercially, as long as they credit the author and license their new creations under the identical terms.",
+  },
+  {
+    label: "CC BY-SA",
+    value: "cc-by-sa",
+    description:
+      "Allows others to remix, tweak, and build upon the work even for commercial purposes, as long as they credit the author and license their new creations under the identical terms.",
+  },
+  {
+    label: "CC BY-ND",
+    value: "cc-by-nd",
+    description:
+      "Allows for redistribution, commercial and non-commercial, as long as the work is passed along unchanged and in whole, with credit to the author.",
+  },
+  {
+    label: "Publisher-Specific Open-Access",
+    value: "publisher-specific-oa",
+    description:
+      "Open access license defined by the publisher, which may include specific restrictions and conditions.",
+  },
+  {
+    label: "Publisher-Specific or Author Manuscript",
+    value: "publisher-specific, author manuscript",
+    description:
+      "Includes publisher-specific licenses or papers that are author manuscripts, possibly with different usage rights.",
+  },
+  {
+    label: "CC0 (Public Domain)",
+    value: "public-domain",
+    description:
+      "Indicates that the author has waived all copyright and related rights, placing the work in the public domain.",
+  },
+  {
+    label: "Other Open-Access",
+    value: "other-oa",
+    description:
+      "Open access license not covered by other categories, may include various less common open-access types.",
+  },
+];


### PR DESCRIPTION
### Updates
- Update copy when PDF isn't viewable
- Use new `pdf_copyright_allows_display` flag from backend to determine whether to enable PDF Upload
- User-uploaded PDF shows in reference manager, even if paper has copyright restrictions
- Saving a paper to the reference manager with a copyrighted PDF won't copy the PDF to the citation
- Let moderators remove PDF from moderator panel
- Let moderators edit license metadata

### Demo
https://www.loom.com/share/e5681b0ccff342f783c5a91c1bbf8835?sid=c0dcf2e2-29f5-4c61-8d26-36fc00e0b9b3

### Test Papers
- Should Show PDF: `oa_status = null` and `pdf_license = cc-by`: https://researchhub-web-git-manveer-pdf-licenses-researchhub.vercel.app/paper/131491/the-lbca-lipoprotein-and-ctpa-protease-assemble-an-oligomeric-complex-to-control-peptidoglycan-hydrolases-in-ipseudomonas-aeruginosai
- Should _NOT_ Show PDF: `oa_status = null` and `pdf_license = null`: https://researchhub-web-git-manveer-pdf-licenses-researchhub.vercel.app/paper/131736/pamlr-a-toolbox-for-analysing-animal-behaviour-using-pressure-acceleration-temperature-magnetic-and-light-data-in-r
- Should Show PDF: `oa_status = gold` and `pdf_license = null`: https://researchhub-web-git-manveer-pdf-licenses-researchhub.vercel.app/paper/131836/formation-of-a-traditional-chinese-medicine-self-assembly-nanostrategy-and-its-application-in-cancer-a-promising-treatment