### PR TITLE
Fix bug that breaks profile page caused by nonexistent variable

### DIFF
--- a/components/ResearchCoin/TransactionCard.js
+++ b/components/ResearchCoin/TransactionCard.js
@@ -94,8 +94,8 @@ const TransactionCard = (props) => {
     if (transaction.readable_content_type === "bounty") {
       title = `Bounty #${transaction.source.id}: ${transaction.source.status}`;
     } else if (
-      withdrawal.readable_content_type === "bountyfee" ||
-      withdrawal.readable_content_type === "supportfee"
+      transaction.readable_content_type === "bountyfee" ||
+      transaction.readable_content_type === "supportfee"
     ) {
       title = "ResearchHub Platform Fee";
     } else if (transaction.readable_content_type === "purchase") {


### PR DESCRIPTION
In #1659, I referenced an object `withdrawal`, when I should have referenced `transaction` ([direct link to code](https://github.com/ResearchHub/researchhub-web/pull/1659/files#diff-10ab370752364b096b3b7edde66413ffdb689293efde6245c376222b656b9b7aR97-R98)). This was a mistake made when copy-pasting from another file.