### PR TITLE
Cannot enter whitespace in Firefox

### DIFF
--- a/components/Comment/lib/quill.css
+++ b/components/Comment/lib/quill.css
@@ -328,8 +328,12 @@
   max-width: 800px;
 }
 
-.CommentEditor .ql-editor {
+/* .CommentEditor .ql-editor {
   white-space: initial;
+} */
+
+.ql-editor {
+  white-space: pre-wrap !important;
 }
 
 .CommentEditor .ql-editor ol,

--- a/components/Comment/lib/quill.css
+++ b/components/Comment/lib/quill.css
@@ -328,10 +328,6 @@
   max-width: 800px;
 }
 
-/* .CommentEditor .ql-editor {
-  white-space: initial;
-} */
-
 .ql-editor {
   white-space: pre-wrap !important;
 }


### PR DESCRIPTION
- Reported on discord
- Cannot enter whitespace in comment editor
- Reported in quill rep: https://github.com/quilljs/quill/issues/1874