### PR TITLE
Fix bug where null href caused paper page to crash

### DIFF
--- a/components/Document/DocumentLineItems.tsx
+++ b/components/Document/DocumentLineItems.tsx
@@ -118,7 +118,9 @@ const DocumentLineItems = ({
                 href={
                   isPaper(document) && document.externalUrl
                     ? document.externalUrl
-                    : `https://` + document.doi
+                    : document.doi.startsWith("http")
+                    ? document.doi
+                    : `https://doi.org/${document.doi}`
                 }
                 target="blank"
               >

--- a/components/Paper/Tabs/PaperTab.js
+++ b/components/Paper/Tabs/PaperTab.js
@@ -162,9 +162,21 @@ function PaperTab(props) {
           <p>
             This paper's license is marked as closed access or non-commercial
             and cannot be viewed on ResearchHub.{" "}
-            <ALink target="_blank" theme="solidPrimary" href={paper.url}>
-              Visit the paper's external site.
-            </ALink>
+            {(paper.url || paper.doi) && (
+              <ALink
+                target="_blank"
+                theme="solidPrimary"
+                href={
+                  paper.url
+                    ? paper.url
+                    : paper.doi?.startsWith("http")
+                    ? paper.doi
+                    : `https://doi.org/${paper.doi?.trim()}`
+                }
+              >
+                Visit the paper's external site.
+              </ALink>
+            )}
           </p>
         </div>
       );


### PR DESCRIPTION
There were a bunch of papers failing to render on the server side because of a `null` value in a `href` tag.

It seems like this may have been caused by `paper.url = null`, and may have newly been surfaced as an issue when we made the change to copyright handling (https://github.com/ResearchHub/researchhub-web/pull/1658).