### PR TITLE
Update UI for bounty minimum and support tipping fee changes

### DIFF
--- a/components/Bounty/BountyModal.tsx
+++ b/components/Bounty/BountyModal.tsx
@@ -78,7 +78,7 @@ function BountyModal({
   useEffect((): void => {
     setHasMinRscAlert(
       currentUserBalance <= MIN_RSC_REQUIRED ||
-        offeredAmount <= MIN_RSC_REQUIRED ||
+        offeredAmount < MIN_RSC_REQUIRED ||
         currentUserBalance < offeredAmount
     );
   }, [currentUserBalance, offeredAmount]);
@@ -395,7 +395,7 @@ function BountyModal({
                         ? `Your RSC balance is below offered amount ${numeral(
                             offeredAmount
                           ).format("0[,]0")}`
-                        : `Minimum bounty must be greater than ${MIN_RSC_REQUIRED} RSC`}
+                        : `Minimum bounty amount is ${MIN_RSC_REQUIRED} RSC`}
                     </div>
                   ) : hasMaxRscAlert ? (
                     <div

--- a/components/Bounty/BountyWizardRSCForm.tsx
+++ b/components/Bounty/BountyWizardRSCForm.tsx
@@ -202,7 +202,7 @@ function BountyWizardRSCForm({
   useEffect((): void => {
     setHasMinRscAlert(
       currentUserBalance <= MIN_RSC_REQUIRED ||
-        offeredAmount <= MIN_RSC_REQUIRED ||
+        offeredAmount < MIN_RSC_REQUIRED ||
         currentUserBalance < offeredAmount
     );
   }, [currentUserBalance, offeredAmount]);
@@ -609,7 +609,7 @@ function BountyWizardRSCForm({
                     ? `Your RSC balance is below offered amount ${numeral(
                         offeredAmount
                       ).format("0[,]0")}`
-                    : `Minimum bounty must be greater than ${MIN_RSC_REQUIRED} RSC`}
+                    : `Minimum bounty amount is ${MIN_RSC_REQUIRED} RSC`}
                 </div>
               ) : hasMaxRscAlert ? (
                 <div className={css(alertStyles.alert, alertStyles.rscAlert)}>

--- a/components/Bounty/config/constants.ts
+++ b/components/Bounty/config/constants.ts
@@ -1,4 +1,4 @@
 export const BOUNTY_DEFAULT_AMOUNT = 1000;
 export const BOUNTY_RH_PERCENTAGE = 9;
-export const MIN_RSC_REQUIRED = 50;
+export const MIN_RSC_REQUIRED = 10;
 export const MAX_RSC_REQUIRED = 1000000;

--- a/components/Modals/ContentSupportModal.js
+++ b/components/Modals/ContentSupportModal.js
@@ -164,11 +164,7 @@ class ContentSupportModal extends Component {
         >
           <div className={css(bountyTooltip.bodyContainer)}>
             <div className={css(bountyTooltip.desc)}>
-              <div>
-                • 1% of tip amount will be used to support the ResearchHub
-                Community
-              </div>
-              <div>• 2% of tip amount will be paid to ResearchHub Inc</div>
+              <div>The tip amount will be paid to ResearchHub Inc</div>
             </div>
           </div>
         </ReactTooltip>
@@ -367,7 +363,6 @@ const alertStyles = StyleSheet.create({
 const bountyTooltip = StyleSheet.create({
   tooltipContainer: {
     textAlign: "left",
-    width: 350,
     padding: 12,
   },
   tooltipContainerSmall: {

--- a/components/Modals/PaperTransactionModal.js
+++ b/components/Modals/PaperTransactionModal.js
@@ -734,11 +734,7 @@ class PaperTransactionModal extends Component {
           >
             <div className={css(bountyTooltip.bodyContainer)}>
               <div className={css(bountyTooltip.desc)}>
-                <div>
-                  • 1% of tip amount will be used to support the ResearchHub
-                  Community
-                </div>
-                <div>• 2% of tip amount will be paid to ResearchHub Inc</div>
+                <div>The tip amount will be paid to ResearchHub Inc</div>
               </div>
             </div>
           </ReactTooltip>
@@ -1022,7 +1018,6 @@ const alertStyles = StyleSheet.create({
 const bountyTooltip = StyleSheet.create({
   tooltipContainer: {
     textAlign: "left",
-    width: 300,
     padding: 12,
   },
   tooltipContainerSmall: {


### PR DESCRIPTION
- Reduce bounty minimum to 10
- Modify logic to allow 10 as a minimum, rather than requiring more than 10 (e.g. 11)
- Update copy for support fee as we're moving the full 3% to RH Inc.