### PR TITLE
Update Node.js version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,19 +19,17 @@ We believe that by empowering scientists to independently fund, create, and publ
 
 ## Important Links 👀
 
-
 💡 Got an idea or request? [Open issue on Github](https://github.com/ResearchHub/researchhub-web/issues).  
-🐛 Found a bug? [Report it here](https://github.com/ResearchHub/researchhub-web/issues).   
-➕ Want to contribute to this project? [Introduce yourself in our Discord community](https://discord.gg/ZcCYgcnUp5)    
-🔨 [See what we are working on](https://github.com/orgs/ResearchHub/projects/2)   
-📰 Read the [ResearchCoin White Paper](https://www.researchhub.com/paper/819400/the-researchcoin-whitepaper)  
-
+🐛 Found a bug? [Report it here](https://github.com/ResearchHub/researchhub-web/issues).  
+➕ Want to contribute to this project? [Introduce yourself in our Discord community](https://discord.gg/ZcCYgcnUp5)  
+🔨 [See what we are working on](https://github.com/orgs/ResearchHub/projects/2)  
+📰 Read the [ResearchCoin White Paper](https://www.researchhub.com/paper/819400/the-researchcoin-whitepaper)
 
 ## Setup
 
 1. Run `cp .env.development.example .env.development`
-1. `nvm install 14.15.5` (installing [nvm](https://github.com/nvm-sh/nvm#installing-and-updating))
-1. `nvm use 14.15.5`
+1. `nvm install 16.20.2` (installing [nvm](https://github.com/nvm-sh/nvm#installing-and-updating))
+1. `nvm use 16.20.2`
 1. `yarn install` (installing [yarn](https://classic.yarnpkg.com/lang/en/docs/install/))
 1. `yarn run dev`
 1. You will also need to [install the backend app](https://github.com/ResearchHub/researchhub-backend) for the project to run


### PR DESCRIPTION
I tried to follow the instructions in `README.md` but failed at step 4 (`yarn install`) because @citation-js/plugin-bibtex requires Node.js version 16.0.0 or higher, but step 2 in the current `README.md` explicitly asks to use 14.15.5. This PR updates the `README.md` to instruct the use of 16.20.2.