### PR TITLE
Fix bug where completed fundraise would show as closed

### DIFF
--- a/components/Fundraise/lib/types.ts
+++ b/components/Fundraise/lib/types.ts
@@ -1,6 +1,6 @@
 import { ID, RHUser, parseUser } from "~/config/types/root_types";
 
-export type FundraiseStatus = "OPEN" | "CLOSED";
+export type FundraiseStatus = "OPEN" | "CLOSED" | "COMPLETED";
 
 export interface Fundraise {
   id: ID;


### PR DESCRIPTION
This PR builds on the backend change (https://github.com/ResearchHub/researchhub-backend/pull/1434) to add a new "COMPLETED" status to a fundraise.

It's meant to fix the bug where RSC price fluctuations caused completed fundraises to show as closed.

Closed fundraise looks like this:
<img width="753" alt="Screenshot 2024-02-15 at 9 34 10 AM" src="https://github.com/ResearchHub/researchhub-web/assets/16143968/296820c4-4d72-4fb3-9b49-15c36a83e729">
