### PR TITLE
Sanitize post html before rendering

### DIFF
--- a/components/Document/api/fetchPostFromS3.ts
+++ b/components/Document/api/fetchPostFromS3.ts
@@ -15,15 +15,27 @@ const fetchPostFromS3 = async ({ s3Url, cleanIntroEmptyContent = true }: Props):
         msg: `Error fetching post from S3`,
       });
     }
-    let _html = await response.text();
-    _html = sanitizeHtml(_html, {
-      allowedTags: sanitizeHtml.defaults.allowedTags.concat(['video', 'source']),
-      allowedAttributes: {
-        ...sanitizeHtml.defaults.allowedAttributes,
-        video: ['src', 'type', 'controls', 'autoplay', 'muted', 'loop', 'width', 'height'],
-        source: ['src', 'type']
-      }
-    });
+    let _html = await response.text().then((text) =>
+      sanitizeHtml(text, {
+        allowedTags: sanitizeHtml.defaults.allowedTags.concat([
+          "source",
+          "video",
+        ]),
+        allowedAttributes: {
+          ...sanitizeHtml.defaults.allowedAttributes,
+          video: [
+            "autoplay",
+            "controls",
+            "height",
+            "loop",
+            "muted",
+            "src",
+            "type",
+            "width",
+          ],
+          source: ["src", "type"],
+        },
+      }));
 
     if (cleanIntroEmptyContent) {
       // CK Editor saves H1 tags on S3.
@@ -34,12 +46,12 @@ const fetchPostFromS3 = async ({ s3Url, cleanIntroEmptyContent = true }: Props):
         /<p>((<br\/?>)*|\s*|(&nbsp;)*)*(.*?<\/p>)/,
         "<p>$4"
       );
-  
+
       // The following appear to be common "empty" content that pushes main content down in CK editor
       const cleanHtml = htmlWithoutIntroWhitespace.replace(
-        /^(<p>\s*<\/p>|<p>&nbsp;<\/p>|<h2>&nbsp;<\/h2>|<h3>&nbsp;<\/h3>|<h1>&nbsp;<\/h1>|<h2>\s*<\/h2>|<h3>\s*<\/h3>|<h1>\s*<\/h1>|\s*)*/gi, 
+        /^(<p>\s*<\/p>|<p>&nbsp;<\/p>|<h2>&nbsp;<\/h2>|<h3>&nbsp;<\/h3>|<h1>&nbsp;<\/h1>|<h2>\s*<\/h2>|<h3>\s*<\/h3>|<h1>\s*<\/h1>|\s*)*/gi,
         ""
-      );    
+      );
 
       _html = cleanHtml;
     }

--- a/components/Document/api/fetchPostFromS3.ts
+++ b/components/Document/api/fetchPostFromS3.ts
@@ -24,6 +24,7 @@ const fetchPostFromS3 = async ({ s3Url, cleanIntroEmptyContent = true }: Props):
         ]),
         allowedAttributes: {
           ...sanitizeHtml.defaults.allowedAttributes,
+          figure: ["class", "style"],
           video: [
             "autoplay",
             "controls",

--- a/components/Document/api/fetchPostFromS3.ts
+++ b/components/Document/api/fetchPostFromS3.ts
@@ -15,29 +15,30 @@ const fetchPostFromS3 = async ({ s3Url, cleanIntroEmptyContent = true }: Props):
         msg: `Error fetching post from S3`,
       });
     }
-    let _html = await response.text().then((text) =>
-      sanitizeHtml(text, {
-        allowedTags: sanitizeHtml.defaults.allowedTags.concat([
-          "img",
-          "source",
-          "video",
-        ]),
-        allowedAttributes: {
-          ...sanitizeHtml.defaults.allowedAttributes,
-          figure: ["class", "style"],
-          video: [
-            "autoplay",
-            "controls",
-            "height",
-            "loop",
-            "muted",
-            "src",
-            "type",
-            "width",
-          ],
-          source: ["src", "type"],
-        },
-      }));
+    let _html = await response.text()
+    _html = sanitizeHtml(_html, {
+      allowedTags: sanitizeHtml.defaults.allowedTags.concat([
+        "img",
+        "source",
+        "video",
+      ]),
+      allowedAttributes: {
+        ...sanitizeHtml.defaults.allowedAttributes,
+        code: ["class"],
+        figure: ["class", "style"],
+        video: [
+          "autoplay",
+          "controls",
+          "height",
+          "loop",
+          "muted",
+          "src",
+          "type",
+          "width",
+        ],
+        source: ["src", "type"],
+      },
+    });
 
     if (cleanIntroEmptyContent) {
       // CK Editor saves H1 tags on S3.

--- a/components/Document/api/fetchPostFromS3.ts
+++ b/components/Document/api/fetchPostFromS3.ts
@@ -16,7 +16,14 @@ const fetchPostFromS3 = async ({ s3Url, cleanIntroEmptyContent = true }: Props):
       });
     }
     let _html = await response.text();
-    _html = sanitizeHtml(_html);
+    _html = sanitizeHtml(_html, {
+      allowedTags: sanitizeHtml.defaults.allowedTags.concat(['video', 'source']),
+      allowedAttributes: {
+        ...sanitizeHtml.defaults.allowedAttributes,
+        video: ['src', 'type', 'controls', 'autoplay', 'muted', 'loop', 'width', 'height'],
+        source: ['src', 'type']
+      }
+    });
 
     if (cleanIntroEmptyContent) {
       // CK Editor saves H1 tags on S3.

--- a/components/Document/api/fetchPostFromS3.ts
+++ b/components/Document/api/fetchPostFromS3.ts
@@ -1,4 +1,5 @@
 import { captureEvent } from "~/config/utils/events";
+import sanitizeHtml from "sanitize-html";
 
 interface Props {
   s3Url: string;
@@ -15,6 +16,7 @@ const fetchPostFromS3 = async ({ s3Url, cleanIntroEmptyContent = true }: Props):
       });
     }
     let _html = await response.text();
+    _html = sanitizeHtml(_html);
 
     if (cleanIntroEmptyContent) {
       // CK Editor saves H1 tags on S3.

--- a/components/Document/api/fetchPostFromS3.ts
+++ b/components/Document/api/fetchPostFromS3.ts
@@ -18,6 +18,7 @@ const fetchPostFromS3 = async ({ s3Url, cleanIntroEmptyContent = true }: Props):
     let _html = await response.text().then((text) =>
       sanitizeHtml(text, {
         allowedTags: sanitizeHtml.defaults.allowedTags.concat([
+          "img",
           "source",
           "video",
         ]),

--- a/components/Document/api/fetchPostFromS3.ts
+++ b/components/Document/api/fetchPostFromS3.ts
@@ -29,8 +29,6 @@ const fetchPostFromS3 = async ({ s3Url, cleanIntroEmptyContent = true }: Props):
       ]),
       allowedAttributes: {
         a: ["href", "name", "target"],
-        code: ["class"],
-        figure: ["class", "style"],
         img: ["src", "srcset", "alt", "title", "width", "height", "loading"],
         video: [
           "autoplay",
@@ -43,6 +41,7 @@ const fetchPostFromS3 = async ({ s3Url, cleanIntroEmptyContent = true }: Props):
           "width",
         ],
         source: ["src", "type"],
+        '*': ["class", "style"],
       },
     });
 

--- a/components/Document/api/fetchPostFromS3.ts
+++ b/components/Document/api/fetchPostFromS3.ts
@@ -18,14 +18,20 @@ const fetchPostFromS3 = async ({ s3Url, cleanIntroEmptyContent = true }: Props):
     let _html = await response.text()
     _html = sanitizeHtml(_html, {
       allowedTags: sanitizeHtml.defaults.allowedTags.concat([
-        "img",
-        "source",
-        "video",
+        "a", "abbr", "address", "article", "aside", "b", "bdi", "bdo",
+        "blockquote", "br", "caption", "cite", "code", "col", "colgroup",
+        "data", "dd", "dfn", "div", "dl", "dt", "em", "figcaption", "figure",
+        "h1", "h2", "h3", "h4", "h5", "h6", "hgroup", "hr", "i", "img", "kbd",
+        "li", "main", "mark", "ol", "p", "pre", "q", "rb", "rp", "rt", "rtc",
+        "ruby", "s", "samp", "section", "small", "source", "span", "strong",
+        "sub", "sup", "table", "tbody", "td", "tfoot", "th", "thead", "time",
+        "tr", "u", "ul", "var", "video", "wbr"
       ]),
       allowedAttributes: {
-        ...sanitizeHtml.defaults.allowedAttributes,
+        a: ["href", "name", "target"],
         code: ["class"],
         figure: ["class", "style"],
+        img: ["src", "srcset", "alt", "title", "width", "height", "loading"],
         video: [
           "autoplay",
           "controls",

--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "redux-thunk": "^2.3.0",
     "remove-markdown": "^0.3.0",
     "safe-url": "^1.0.0",
+    "sanitize-html": "^2.12.1",
     "slate": "0.47.8",
     "slate-html-serializer": "^0.8.13",
     "slate-plain-serializer": "^0.7.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4804,6 +4804,11 @@ deepmerge@^1.5.2:
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.5.2.tgz#10499d868844cdad4fee0842df8c7f6f0c95a753"
   integrity sha512-95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ==
 
+deepmerge@^4.2.2:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
+  integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
+
 define-properties@^1.1.2, define-properties@^1.1.3, define-properties@^1.1.4, define-properties@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.2.0.tgz#52988570670c9eacedd8064f4a990f2405849bd5"
@@ -4947,6 +4952,15 @@ dom-serializer@0:
     domelementtype "^2.0.1"
     entities "^2.0.0"
 
+dom-serializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
+  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    entities "^4.2.0"
+
 domain-browser@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
@@ -4957,7 +4971,7 @@ domelementtype@1, domelementtype@^1.3.1:
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
   integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
 
-domelementtype@^2.0.1:
+domelementtype@^2.0.1, domelementtype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
   integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
@@ -4969,6 +4983,13 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
+domhandler@^5.0.2, domhandler@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
+  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
+  dependencies:
+    domelementtype "^2.3.0"
+
 domutils@^1.5.1:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
@@ -4976,6 +4997,15 @@ domutils@^1.5.1:
   dependencies:
     dom-serializer "0"
     domelementtype "1"
+
+domutils@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.1.0.tgz#c47f551278d3dc4b0b1ab8cbb42d751a6f0d824e"
+  integrity sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==
+  dependencies:
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
 
 draft-convert@^2.1.10:
   version "2.1.13"
@@ -5121,6 +5151,11 @@ entities@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
+
+entities@^4.2.0, entities@^4.4.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
+  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
 envinfo@^7.7.3:
   version "7.8.1"
@@ -6454,6 +6489,16 @@ htmlparser2@^3.9.0:
     inherits "^2.0.1"
     readable-stream "^3.1.1"
 
+htmlparser2@^8.0.0:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-8.0.2.tgz#f002151705b383e62433b5cf466f5b716edaec21"
+  integrity sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+    domutils "^3.0.1"
+    entities "^4.4.0"
+
 http-proxy-agent@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz#8a8c8ef7f5932ccf953c296ca8291b95aa74aa3a"
@@ -6943,6 +6988,11 @@ is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
   dependencies:
     isobject "^3.0.1"
+
+is-plain-object@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
+  integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
 
 is-reference@1.2.1:
   version "1.2.1"
@@ -8081,6 +8131,11 @@ nanoid@^3.3.4:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
   integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
 
+nanoid@^3.3.7:
+  version "3.3.7"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.7.tgz#d0c301a691bc8d54efa0a2226ccf3fe2fd656bd8"
+  integrity sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -8554,6 +8609,11 @@ parse-json@^5.0.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
+parse-srcset@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/parse-srcset/-/parse-srcset-1.0.2.tgz#f2bd221f6cc970a938d88556abc589caaaa2bde1"
+  integrity sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==
+
 pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
@@ -8829,6 +8889,15 @@ postcss@^7.0.0:
   dependencies:
     picocolors "^0.2.1"
     source-map "^0.6.1"
+
+postcss@^8.3.11:
+  version "8.4.35"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.35.tgz#60997775689ce09011edf083a549cea44aabe2f7"
+  integrity sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==
+  dependencies:
+    nanoid "^3.3.7"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
 
 preact@^10.12.0, preact@^10.5.9:
   version "10.14.1"
@@ -10064,6 +10133,18 @@ safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+sanitize-html@^2.12.1:
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-2.12.1.tgz#280a0f5c37305222921f6f9d605be1f6558914c7"
+  integrity sha512-Plh+JAn0UVDpBRP/xEjsk+xDCoOvMBwQUf/K+/cBAVuTbtX8bj2VB7S1sL1dssVpykqp0/KPSesHrqXtokVBpA==
+  dependencies:
+    deepmerge "^4.2.2"
+    escape-string-regexp "^4.0.0"
+    htmlparser2 "^8.0.0"
+    is-plain-object "^5.0.0"
+    parse-srcset "^1.0.2"
+    postcss "^8.3.11"
 
 scheduler@^0.23.0:
   version "0.23.0"


### PR DESCRIPTION
Sanitize post html before rendering to avoid XSS attacks. I decided to just use the default attributes listed here https://github.com/apostrophecms/sanitize-html?tab=readme-ov-file#default-options plus video and tested it by creating a note with each of the rich editing features. 

We are not sanitizing the notebooks on creation because we will be migrating away from CKEditor so we will address those changes along with a sanitization of any existing notes. 