### PR TITLE
Various hotfixes for search suggestions

### DIFF
--- a/components/Author/AuthorList.tsx
+++ b/components/Author/AuthorList.tsx
@@ -32,8 +32,10 @@ const Author = ({ author }: { author: AuthorProfile }) => {
 
 export const CondensedAuthorList = ({
   authors,
+  numPrimaryAuthorsToShow = 2,
 }: {
   authors: Array<AuthorProfile>;
+  numPrimaryAuthorsToShow?: number;
 }) => {
   if (authors.length === 0) {
     return null;
@@ -42,12 +44,12 @@ export const CondensedAuthorList = ({
   const primaryAuthors: Array<AuthorProfile> = [authors[0]];
   let showEtAllText = false;
 
-  if (authors.length > 1) {
+  if (numPrimaryAuthorsToShow > 1 && authors.length > 1) {
     // Last author is the second most important author
     primaryAuthors.push(authors[authors.length - 1]);
   }
 
-  if (authors.length > 2) {
+  if (authors.length > numPrimaryAuthorsToShow) {
     showEtAllText = true;
   }
 

--- a/components/SearchSuggestion/SearchAutosuggest.tsx
+++ b/components/SearchSuggestion/SearchAutosuggest.tsx
@@ -14,7 +14,7 @@ import { CondensedAuthorList } from "../Author/AuthorList";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faGrid2 } from "@fortawesome/pro-solid-svg-icons";
 import { toTitleCase } from "~/config/utils/string";
-
+import { formatNumber } from "~/config/utils/number";
 
 interface SearchSuggestionProps {
   suggestions: Suggestion[];
@@ -81,6 +81,7 @@ const HubSuggestion = ({
     hubName,
     textToHighlight
   );
+  const formattedNumDocs = formatNumber(suggestion.hub.numDocs || 0);
 
   return (
     <div className={css(styles.recordWrapper)}>
@@ -100,7 +101,7 @@ const HubSuggestion = ({
           {suggestion.hub.numDocs && suggestion.hub.numDocs > 0 && (
             <>
               <div className={css(styles.divider)} />
-              <div>{suggestion.hub.numDocs} papers</div>
+              <div>{formattedNumDocs} papers</div>
             </>
           )}
         </div>
@@ -141,7 +142,10 @@ const PaperSuggestion = ({
           {suggestion.authors.length > 0 && (
             <>
               <div className={css(styles.divider)} />
-              <CondensedAuthorList authors={suggestion.authors} />
+              <CondensedAuthorList
+                authors={suggestion.authors}
+                numPrimaryAuthorsToShow={1}
+              />
             </>
           )}
           {suggestion.publishedDate && (
@@ -188,7 +192,10 @@ const PostSuggestion = ({
           {suggestion.authors.length > 0 && (
             <>
               <div className={css(styles.divider)} />
-              <CondensedAuthorList authors={suggestion.authors} />
+              <CondensedAuthorList
+                authors={suggestion.authors}
+                numPrimaryAuthorsToShow={1}
+              />
             </>
           )}
           {suggestion.createdDate && (
@@ -230,7 +237,10 @@ const QuestionSuggestion = ({
           {suggestion.authors.length > 0 && (
             <>
               <div className={css(styles.divider)} />
-              <CondensedAuthorList authors={suggestion.authors} />
+              <CondensedAuthorList
+                authors={suggestion.authors}
+                numPrimaryAuthorsToShow={1}
+              />
             </>
           )}
           {suggestion.createdDate && (
@@ -314,8 +324,7 @@ const styles = StyleSheet.create({
   recordTitle: {
     whiteSpace: "nowrap",
     overflow: "hidden",
-    textOverflow:
-      "ellipsis",
+    textOverflow: "ellipsis",
     maxWidth: "90%",
   },
   divider: {
@@ -331,9 +340,8 @@ const styles = StyleSheet.create({
     display: "flex",
     whiteSpace: "nowrap",
     overflow: "hidden",
-    textOverflow:
-      "ellipsis",
-    maxWidth: "95%",    
+    textOverflow: "ellipsis",
+    maxWidth: "85%",
   },
   recordWrapper: {
     display: "flex",

--- a/components/SearchSuggestion/lib/api.ts
+++ b/components/SearchSuggestion/lib/api.ts
@@ -23,7 +23,16 @@ export const fetchAllSuggestions = (
       }
     })
     .then((rawSuggestions) => {
-      return rawSuggestions.map(raw => parseSuggestion(raw))
+      return rawSuggestions
+        .map((raw) => {
+          try {
+            return parseSuggestion(raw);
+          } catch (err) {
+            console.warn("Failed to parse suggestion: ", raw, "Error: ", err);
+            return null;
+          }
+        })
+        .filter((suggestion) => suggestion !== null);
     })
     .catch((error) => {
       console.error("Request Failed:", error);


### PR DESCRIPTION
- Only show one author in search results for width purposes
- Format number of papers in hub results to include a comma
- Debounce calls to suggest endpoint
- Ensure that if one result fails to parse, the whole result set doesn't