### PR TITLE
Set focus on password field after entering email

### DIFF
--- a/components/Login/LoginModal.tsx
+++ b/components/Login/LoginModal.tsx
@@ -425,7 +425,6 @@ const LoginModal = ({
               containerStyle={styles.inputContainer}
               placeholder="Email"
               autoComplete="email"
-              autoFocus={!isMobileScreen}
               error={emailError}
               getRef={emailRef}
               type="email"
@@ -447,6 +446,7 @@ const LoginModal = ({
               containerStyle={styles.inputContainerShort}
               placeholder="Password"
               type="password"
+              autoFocus={!isMobileScreen}
               onKeyDown={(e) => {
                 e.keyCode === 13 && loginApi(e);
               }}


### PR DESCRIPTION
When logging in with username and password, set the focus on the password field, so the user does not need to manually focus the password field.

<img width="468" alt="image" src="https://github.com/ResearchHub/researchhub-web/assets/6155241/9201a91a-84ca-4b39-8841-4968ae909282">
