### PR TITLE
[Verification] Remove common email validation since legit author do n…

### DIFF
--- a/components/Verification/VerificationFormSelectAuthorStep.tsx
+++ b/components/Verification/VerificationFormSelectAuthorStep.tsx
@@ -61,8 +61,6 @@ const VerificationFormSelectAuthorStep = ({
     }
     if (!isValidEmail(email)) {
       return { isValid: false, error: "INVALID_EMAIL_ERROR" };
-    } else if (isCommonEmailExt(email)) {
-      return { isValid: false, error: "COMMON_EMAIL_ERROR" };
     } else {
       return { isValid: true, error: null };
     }


### PR DESCRIPTION
- A bunch of legit authors been trying to verify authorship with common emails such as gmail, etc..
- This is okay in many cases given that these authors have been outside of academia for some time and do not have access to their institutional email