### PR TITLE
Fix issue with adding valid DOIs to ref manager

### DIFF
--- a/components/ReferenceManager/references/reference_uploader/reference_upload_utils.ts
+++ b/components/ReferenceManager/references/reference_uploader/reference_upload_utils.ts
@@ -84,7 +84,6 @@ export function parseDoiSearchResultOntoValueSet({
     },
     required: referenceSchemaValueSet.required,
   };
-  
   setReferenceSchemaValueSet(schemaSet);
 }
 

--- a/components/ReferenceManager/references/reference_uploader/reference_upload_utils.ts
+++ b/components/ReferenceManager/references/reference_uploader/reference_upload_utils.ts
@@ -73,7 +73,7 @@ export function parseDoiSearchResultOntoValueSet({
       date: !isEmpty(issued) ? moment(issued).format("MM-DD-YYYY") : "",
       DOI: doi,
       title: formattedTitle,
-      ISSN: issn.join(", "),
+      ISSN: Array.isArray(issn) ? issn.join(", ") : "",  // ensure issn is an array
       pdf_url: pdf_url,
       URL: landing_page_url,
       signed_pdf_url,
@@ -84,7 +84,7 @@ export function parseDoiSearchResultOntoValueSet({
     },
     required: referenceSchemaValueSet.required,
   };
-
+  
   setReferenceSchemaValueSet(schemaSet);
 }
 


### PR DESCRIPTION
This PR aims to solve https://github.com/ResearchHub/issues/issues/34.

The issue seems to have been `issn.join` failing if `issn` is `null` or not an array. The fix involves adding a check to ensure `issn` is an array before calling the `join` method. The updated code uses `Array.isArray(issn) ? issn.join(", ") : ""`, which checks if `issn` is an array; if it is, it joins the array elements into a string separated by commas. If `issn` is not an array or is `null`, it defaults to an empty string. This prevents the application from throwing an error when trying to call `join` on a `null` value.

I ran the code locally and was able to add the DOI that caused the issue:

![image](https://github.com/ResearchHub/researchhub-web/assets/15076450/cdf102f5-813f-403a-b80b-dfc8701c726e)
