### PR TITLE
Fix unknown setting warning

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -32,15 +32,6 @@ const nextConfig = {
       "d2ogkcqdn9wsvr.cloudfront.net",
     ],
   },
-  sentry: {
-    // Use `hidden-source-map` rather than `source-map` as the Webpack `devtool`
-    // for client-side builds. (This will be the default starting in
-    // `@sentry/nextjs` version 8.0.0.) See
-    // https://webpack.js.org/configuration/devtool/ and
-    // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#use-hidden-source-map
-    // for more information.
-    hideSourceMaps: true,
-  },
   env: {
     SENTRY_RELEASE: process.env.SENTRY_RELEASE,
     REACT_APP_ENV: process.env.REACT_APP_ENV,
@@ -145,6 +136,7 @@ const nextConfig = {
 const SentryWebpackPluginOptions = {
   silent: true,
   disableClientWebpackPlugin: false,
+  hideSourceMaps: true,
 };
 
 module.exports = withTM({ ...nextConfig });


### PR DESCRIPTION
- Remove the key for `sentry`.
- Move the option for hidden source maps to the Sentry section.

This will fix the following warning messages when running a build:
```
- warn Invalid next.config.js options detected: 
- warn     The root value has an unexpected property, sentry, which is not in the list of allowed properties (amp, analyticsId, assetPrefix, basePath, cleanDistDir, compiler, compress, configOrigin, crossOrigin, devIndicators, distDir, env, eslint, excludeDefaultMomentLocales, experimental, exportPathMap, generateBuildId, generateEtags, headers, httpAgentOptions, i18n, images, modularizeImports, onDemandEntries, optimizeFonts, output, outputFileTracing, pageExtensions, poweredByHeader, productionBrowserSourceMaps, publicRuntimeConfig, reactStrictMode, redirects, rewrites, sassOptions, serverRuntimeConfig, skipMiddlewareUrlNormalize, skipTrailingSlashRedirect, staticPageGenerationTimeout, swcMinify, target, trailingSlash, transpilePackages, typescript, useFileSystemPublicRoutes, webpack).
- warn See more info here: https://nextjs.org/docs/messages/invalid-next-config
```