### PR TITLE
Add Github Action to mirror master branch

### DIFF
--- a/.github/workflows/mirror-master.yml
+++ b/.github/workflows/mirror-master.yml
@@ -1,0 +1,27 @@
+name: Mirror Master Branch
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Git
+        run: |
+          git config --global user.email "github-actions[bot]@users.no-reply.github.com"
+          git config --global user.name "github-actions[bot]"
+
+      - name: Mirror master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git fetch origin master
+          git update-ref refs/heads/master-mirror refs/remotes/origin/master
+          git push --force origin master-mirror

--- a/.github/workflows/mirror-master.yml
+++ b/.github/workflows/mirror-master.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Mirror master
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}
         run: |
           git fetch origin master
           git update-ref refs/heads/master-mirror refs/remotes/origin/master


### PR DESCRIPTION
This change adds a Github Action that mirrors the `master` branch on every push in `master-mirror`. The mirrored branch will be used as the base branch for a staging environment in Vercel.

Closes researchhub/issues#75