### PR TITLE
Check for user ID in `UserPopover` component

### DIFF
--- a/components/Tooltips/RSC/RSCTooltip.tsx
+++ b/components/Tooltips/RSC/RSCTooltip.tsx
@@ -3,11 +3,8 @@ import { StyleSheet, css } from "aphrodite";
 
 // Components
 import ResearchHubPopover from "~/components/ResearchHubPopover";
-import UserPopover from "./UserPopover";
 
 // Utils
-import { RHUser } from "~/config/types/root_types";
-import { genClientId } from "~/config/utils/id";
 import { getIsOnMobileScreenSize } from "~/config/utils/getIsOnMobileScreenSize";
 import RSCPopover from "./RSCPopover";
 

--- a/components/Tooltips/User/UserTooltip.tsx
+++ b/components/Tooltips/User/UserTooltip.tsx
@@ -24,7 +24,7 @@ export default function UserTooltip({
   targetContent,
   positions,
   overrideTargetStyle,
-}: UserTooltipProps): ReactElement {
+}: UserTooltipProps): ReactElement | null {
   const [userPopoverOpen, setUserPopoverOpen] = useState(false);
 
   const inPopoverRef = useRef(false);
@@ -32,6 +32,10 @@ export default function UserTooltip({
   const leavePopoverTimeout = useRef(null);
 
   const isMobileScreen = getIsOnMobileScreenSize();
+
+  if (!createdBy?.id) {
+    return null;
+  }
 
   return (
     <ResearchHubPopover
@@ -112,5 +116,5 @@ const styles = StyleSheet.create({
   targetWrapper: {
     padding: 4,
     margin: -4,
-  }
+  },
 });


### PR DESCRIPTION
Check if user ID is present before rending the `UserPopover` component. In the current form, a `UserPopover` gets rendered with a user ID of `undefined`. This in turn invokes requests to the backend that causes unhandled error (which will be addressed in a separate PR).