### PR TITLE
Use publication resource for add publications

### DIFF
--- a/components/Publication/lib/api.ts
+++ b/components/Publication/lib/api.ts
@@ -58,7 +58,7 @@ export const addPublicationsToAuthor = ({
   openAlexPublicationIds: ID[];
   openAlexAuthorId?: ID;
 }) => {
-  const url = generateApiUrl(`author/${authorId}/add_publications`);
+  const url = generateApiUrl(`author/${authorId}/publications`);
   return fetch(
     url,
     API.POST_CONFIG({


### PR DESCRIPTION
Use the `/author/<ID>/publication` resource for creating author-publication relations (i.e., `POST`ing to the resource).