### PR TITLE
Remove authorship in paper claim process

### DIFF
--- a/components/Author/Profile/AuthorPublications.tsx
+++ b/components/Author/Profile/AuthorPublications.tsx
@@ -8,7 +8,6 @@ import { css, StyleSheet } from "aphrodite";
 import { useEffect, useState } from "react";
 import {
   UnifiedCard,
-  getDocumentCard,
 } from "~/components/UnifiedDocFeed/utils/getDocumentCard";
 import AddPublicationsModal from "~/components/Publication/AddPublicationsModal";
 import { ROUTES as WS_ROUTES } from "~/config/ws";
@@ -31,12 +30,6 @@ import {
   getFEUnifiedDocType,
 } from "~/config/utils/getUnifiedDocType";
 import FeedCard from "../Tabs/FeedCard";
-import {
-  Authorship,
-  parseGenericDocument,
-  parsePaper,
-} from "~/components/Document/lib/types";
-import MoreHoriz from "@mui/icons-material/MoreHoriz";
 import ClaimRewardsModal from "~/components/ResearchCoin/ClaimRewardsModal";
 import ClaimRewardsButton from "~/components/shared/ClaimRewardsButton";
 import { getRewardsEligibilityInfo } from "~/components/ResearchCoin/lib/rewardsUtil";
@@ -48,8 +41,6 @@ import { MessageActions } from "~/redux/message";
 import { useAlert } from "react-alert";
 import { Tooltip } from "@mui/material";
 import VerifyIdentityModal from "~/components/Verification/VerifyIdentityModal";
-import { faLongArrowDown } from "@fortawesome/pro-regular-svg-icons";
-import { ClipLoader } from "react-spinners";
 import LoadMore from "~/components/shared/LoadMore";
 import SearchEmpty from "~/components/Search/SearchEmpty";
 import { breakpoints } from "~/config/themes/screen";
@@ -77,12 +68,10 @@ const AuthorPublications = ({
     isOpen: boolean;
     paperId: string | null;
     paperTitle: string;
-    authorship: Authorship | null;
   }>({
     isOpen: false,
     paperId: null,
     paperTitle: "",
-    authorship: null,
   });
 
   const resetRewardsModalState = () => {
@@ -90,7 +79,6 @@ const AuthorPublications = ({
       isOpen: false,
       paperId: null,
       paperTitle: "",
-      authorship: null,
     });
   };
 
@@ -103,6 +91,8 @@ const AuthorPublications = ({
     setFullAuthorProfile,
     setIsLoadingPublications,
     isLoadingPublications,
+    summaryStats,
+    setSummaryStats,
   } = authorProfileContext();
 
   useEffect(() => {
@@ -174,7 +164,6 @@ const AuthorPublications = ({
         paperId={rewardsModalState.paperId}
         isOpen={rewardsModalState.isOpen}
         paperTitle={rewardsModalState.paperTitle}
-        authorship={rewardsModalState.authorship}
         closeModal={() => resetRewardsModalState()}
       />
 
@@ -355,10 +344,9 @@ const AuthorPublications = ({
                                   ...publicationsResponse,
                                 };
 
-                                fullAuthorProfile.summaryStats.worksCount =
-                                  fullAuthorProfile.summaryStats.worksCount - 1;
-                                setFullAuthorProfile({ ...fullAuthorProfile });
+                                summaryStats.worksCount = summaryStats.worksCount - 1
                                 setPublicationsResponse(updatedResponse);
+                                setSummaryStats({ ...summaryStats });
                               })
                               .catch(() => {
                                 dispatch(
@@ -389,11 +377,6 @@ const AuthorPublications = ({
                               setRewardsModalState({
                                 paperId: targetDoc.id,
                                 paperTitle: targetDoc.title,
-                                authorship:
-                                  authors.find(
-                                    (author) =>
-                                      author.id === fullAuthorProfile.id
-                                  ) || null,
                                 isOpen: true,
                               });
                             }}

--- a/components/Author/Profile/AuthorPublications.tsx
+++ b/components/Author/Profile/AuthorPublications.tsx
@@ -14,7 +14,7 @@ import AddPublicationsModal from "~/components/Publication/AddPublicationsModal"
 import { ROUTES as WS_ROUTES } from "~/config/ws";
 import { useSelector, connect, useDispatch } from "react-redux";
 import Button from "~/components/Form/Button";
-import { ID, parseUser } from "~/config/types/root_types";
+import { ID, parseAuthorProfile, parseUser } from "~/config/types/root_types";
 import { RootState } from "~/redux";
 import { filterNull, isEmpty } from "~/config/utils/nullchecks";
 import UnifiedDocFeedCardPlaceholder from "~/components/UnifiedDocFeed/UnifiedDocFeedCardPlaceholder";
@@ -33,7 +33,6 @@ import {
 import FeedCard from "../Tabs/FeedCard";
 import {
   Authorship,
-  parseAuthorship,
   parseGenericDocument,
   parsePaper,
 } from "~/components/Document/lib/types";
@@ -304,6 +303,8 @@ const AuthorPublications = ({
                       : docTypeLabel === "discussion"
                         ? "post"
                         : docTypeLabel;
+
+
                   const targetDoc = !RESEARCHHUB_POST_DOCUMENT_TYPES.includes(
                     formattedDocType
                   )
@@ -311,11 +312,11 @@ const AuthorPublications = ({
                     : uniDoc.documents[0];
                   const docID = targetDoc.id;
 
-                  const authorships: Authorship[] =
-                    targetDoc.authorships.map(parseAuthorship);
+
+                  const authors = targetDoc.authors.map(parseAuthorProfile);
 
                   const rewardEligibilityInfo = getRewardsEligibilityInfo({
-                    authorships,
+                    authors,
                     fullAuthorProfile,
                     targetDoc,
                     isOpenAccess: targetDoc.is_open_access,
@@ -389,9 +390,9 @@ const AuthorPublications = ({
                                 paperId: targetDoc.id,
                                 paperTitle: targetDoc.title,
                                 authorship:
-                                  authorships.find(
-                                    (authorship) =>
-                                      authorship.authorId === fullAuthorProfile.id
+                                  authors.find(
+                                    (author) =>
+                                      author.id === fullAuthorProfile.id
                                   ) || null,
                                 isOpen: true,
                               });

--- a/components/Author/Tabs/FeedCard.tsx
+++ b/components/Author/Tabs/FeedCard.tsx
@@ -23,7 +23,6 @@ import { PaperActions } from "~/redux/paper";
 import {
   AuthorProfile,
   RhDocumentType,
-  UnifiedDocument,
 } from "~/config/types/root_types";
 import { useState, useEffect, SyntheticEvent } from "react";
 import colors, {
@@ -41,7 +40,6 @@ import ContentBadge from "~/components/ContentBadge";
 import { useRouter } from "next/router";
 import Link from "next/link";
 import {
-  Authorship,
   Paper,
   Post,
   parsePaper,
@@ -304,8 +302,6 @@ function FeedCard({
     numOfVisibleHubs--;
   }
 
-  console.log('authors', authors)
-
   return (
     <div
       className={css(
@@ -388,13 +384,15 @@ function FeedCard({
                                   }
                                 }}
                               >
-                                {authors.map((author) => (
-                                  <Tooltip title={author.firstName + " " + author.lastName}>
-                                    <Avatar src={author.profileImage} sx={{ width: 22, height: 22, fontSize: 13, }}>
-                                      {isEmpty(author.profileImage) && (author.firstName || "")[0]}
-                                    </Avatar>
-                                  </Tooltip>
-                                ))}
+                                {authors.map((author) => {
+                                  return (
+                                    <Tooltip title={author.firstName + " " + author.lastName}>
+                                      <Avatar src={author.profileImage} sx={{ width: 22, height: 22, fontSize: 13, }}>
+                                        {isEmpty(author.profileImage) && (author.firstName || "")[0]}
+                                      </Avatar>
+                                    </Tooltip>
+                                  )
+                                })}
                               </AvatarGroup>
                             </div>
 

--- a/components/Author/Tabs/FeedCard.tsx
+++ b/components/Author/Tabs/FeedCard.tsx
@@ -44,7 +44,6 @@ import {
   Authorship,
   Paper,
   Post,
-  parseAuthorship,
   parsePaper,
   parsePost,
 } from "~/components/Document/lib/types";
@@ -305,25 +304,7 @@ function FeedCard({
     numOfVisibleHubs--;
   }
 
-  // We want to shim all authors into the authorship format so it renders properly.
-  // To properly address, we will need to refactor this component.
-  let authorships: Authorship[] = [];
-  if (document?.authorships?.length > 0) {
-    authorships = document.authorships.map(a => parseAuthorship(a));
-  }
-  else if (authors && authors.length > 0) {
-    authorships = authors.map(a => {
-      const rawAuthorship = {
-        raw_author_name: a.firstName + " " + a.lastName,
-        id: a.id,
-        author: {
-          profile_image: a.profileImage,
-          id: a.id,
-        }
-      }
-      return parseAuthorship(rawAuthorship);
-    });
-  }
+  console.log('authors', authors)
 
   return (
     <div
@@ -376,12 +357,12 @@ function FeedCard({
 
                         <div style={{ display: "flex" }}>
                           <div style={{ display: "flex", gap: 5, alignItems: "center", width: "100%", }}>
-                            {Boolean(authorships[0]) && (
+                            {Boolean(authors[0]) && (
                               <span className={css(styles.authors)}>
-                                {authorships[0].rawAuthorName}
+                                {authors[0].firstName + " " + authors[0].lastName}
                               </span>
                             )}
-                            {authorships?.length > 1 && <span>{` et al.`}</span>}
+                            {authors?.length > 1 && <span>{` et al.`}</span>}
 
                             {parsedDoc?.createdDate && (
                               <>
@@ -394,7 +375,7 @@ function FeedCard({
 
                             <div style={{ alignSelf: "flex-end", marginLeft: "auto", }}>
                               <AvatarGroup
-                                total={authorships.length}
+                                total={authors.length}
                                 max={4}
                                 spacing={6}
                                 componentsProps={{
@@ -407,10 +388,10 @@ function FeedCard({
                                   }
                                 }}
                               >
-                                {authorships.map((authorship) => (
-                                  <Tooltip title={authorship.rawAuthorName}>
-                                    <Avatar src={authorship.author.profileImage} sx={{ width: 22, height: 22, fontSize: 13, }}>
-                                      {isEmpty(authorship.author.profileImage) && authorship.rawAuthorName[0]}
+                                {authors.map((author) => (
+                                  <Tooltip title={author.firstName + " " + author.lastName}>
+                                    <Avatar src={author.profileImage} sx={{ width: 22, height: 22, fontSize: 13, }}>
+                                      {isEmpty(author.profileImage) && (author.firstName || "")[0]}
                                     </Avatar>
                                   </Tooltip>
                                 ))}

--- a/components/Document/lib/types.ts
+++ b/components/Document/lib/types.ts
@@ -91,12 +91,8 @@ export type ReviewSummary = {
 };
 
 export type Authorship = {
-  id: ID;
-  authorId: ID;
   authorPosition: "first" | "last" | "middle";
   isCorresponding: boolean;
-  rawAuthorName: string;
-  author: AuthorProfile;
 };
 
 export interface GenericDocument {
@@ -133,7 +129,6 @@ export type Paper = GenericDocument & {
   pdfUrl?: string;
   proxyPdfUrl?: string;
   pdfCopyrightAllowsDisplay?: boolean;
-  authorships: Authorship[];
 };
 
 export type Post = GenericDocument & {
@@ -162,17 +157,6 @@ export const parseNote = (raw: any): Note => {
   return {
     id: raw.id,
     organization: parseOrganization(raw.organization),
-  };
-};
-
-export const parseAuthorship = (raw: any): Authorship => {
-  return {
-    id: raw.id,
-    authorId: raw.author_id,
-    authorPosition: raw.author_position,
-    isCorresponding: raw.is_corresponding,
-    rawAuthorName: raw.raw_author_name,
-    author: parseAuthorProfile(raw.author),
   };
 };
 
@@ -231,7 +215,6 @@ export const parsePaper = (raw: any, shouldStripHTML = true): Paper => {
     pdfUrl: raw.pdf_url,
     proxyPdfUrl: raw.pdf_url ? proxyApi.generateProxyUrl(raw.pdf_url) : null,
     pdfCopyrightAllowsDisplay: Boolean(raw.pdf_copyright_allows_display),
-    authorships: (raw.authorships || []).map((a: any) => parseAuthorship(a)),
     ...(raw.pdf_license && { license: raw.pdf_license }),
   };
 

--- a/components/Notifications/NotificationEntry.js
+++ b/components/Notifications/NotificationEntry.js
@@ -90,7 +90,7 @@ const NotificationEntry = (props) => {
     if (notification_type === "IDENTITY_VERIFICATION_UPDATED") {
       return "Congratulations! Your account has been verified by the ResearchHub team. ";
     } else if (notification_type === "PAPER_CLAIM_PAYOUT") {
-      return "Congratulations! You claim has been approved and RSC has been awarded to your account.";
+      return "Congratulations! Your claim has been approved and RSC has been awarded to your account.";
     } else if (notification_type === "PUBLICATIONS_ADDED") {
       return (
         <div style={{ display: "flex", flexDirection: "column" }}>

--- a/components/ResearchCoin/ClaimRewardsModal.tsx
+++ b/components/ResearchCoin/ClaimRewardsModal.tsx
@@ -15,7 +15,6 @@ import {
 import { submitRewardsClaim, fetchEligiblePaperRewards } from "./lib/api";
 import useCurrentUser from "~/config/hooks/useCurrentUser";
 import { ID } from "~/config/types/root_types";
-import { Authorship } from "../Document/lib/types";
 import { RewardSummary, parseRewardSummary } from "./lib/types";
 import ClaimRewardSummary from "./lib/ClaimRewardSummary";
 import FormInput from "../Form/FormInput";
@@ -29,7 +28,6 @@ interface Props {
   isOpen: boolean;
   paperId: ID;
   paperTitle: string;
-  authorship: Authorship | null;
   closeModal: () => void;
 }
 
@@ -128,7 +126,6 @@ const blockStyles = StyleSheet.create({
 const ClaimRewardsModal = ({
   paperId,
   paperTitle,
-  authorship,
   isOpen,
   closeModal,
 }: Props) => {
@@ -167,7 +164,6 @@ const ClaimRewardsModal = ({
     try {
       const response = await submitRewardsClaim({
         paperId,
-        authorshipId: authorship!.id,
         userId: currentUser.id,
         preregistrationUrl,
         openDataUrl,

--- a/components/ResearchCoin/lib/api.ts
+++ b/components/ResearchCoin/lib/api.ts
@@ -4,7 +4,6 @@ import { Helpers } from "@quantfive/js-web-config";
 
 interface Props {
   paperId: ID;
-  authorshipId: ID;
   userId: ID;
   preregistrationUrl?: string | null;
   openDataUrl?: string | null;
@@ -12,7 +11,6 @@ interface Props {
 
 export const submitRewardsClaim = ({
   paperId,
-  authorshipId,
   userId,
   preregistrationUrl,
   openDataUrl,
@@ -22,7 +20,6 @@ export const submitRewardsClaim = ({
     url,
     API.POST_CONFIG({
       target_paper_id: paperId,
-      authorship_id: authorshipId,
       requestor: userId,
       creator: userId,
       ...(openDataUrl ? {open_data_url: openDataUrl} : {}),

--- a/components/ResearchCoin/lib/rewardsUtil.ts
+++ b/components/ResearchCoin/lib/rewardsUtil.ts
@@ -1,3 +1,6 @@
+import { FullAuthorProfile } from "~/components/Author/lib/types";
+import { AuthorProfile } from "~/config/types/root_types";
+
 export type ineligibleReason =
   | "NOT_OPEN_ACCESS"
   | "NOT_SUPPORTED_TYPE"
@@ -10,15 +13,20 @@ export type RewardsEligibilityInfo = {
 };
 
 export const getRewardsEligibilityInfo = ({
-  authorships,
+  authors,
   fullAuthorProfile,
   targetDoc,
   isOpenAccess,
+}: {
+  authors: AuthorProfile[];
+  fullAuthorProfile: FullAuthorProfile;
+  targetDoc: any;
+  isOpenAccess: boolean;
 }): RewardsEligibilityInfo => {
-  const isFirstAuthor = authorships.find(
-    (authorship) =>
-      authorship.authorPosition === "first" &&
-      authorship.authorId === fullAuthorProfile.id
+  const isFirstAuthor = authors.find(
+    (author) =>
+      author?.authorship?.authorPosition === "first" &&
+      author.id === fullAuthorProfile.id
   );
   const isSupportedType = ["article", "preprint"].includes(
     targetDoc?.work_type
@@ -34,7 +42,7 @@ export const getRewardsEligibilityInfo = ({
   }
 
   return {
-    isEligibleForRewards: isFirstAuthor && isSupportedType,
+    isEligibleForRewards: Boolean(isFirstAuthor && isSupportedType),
     reason: ineligibleReason,
   };
 };

--- a/config/types/root_types.ts
+++ b/config/types/root_types.ts
@@ -3,6 +3,7 @@ import { Hub } from "./hub";
 import Bounty from "./bounty";
 import { Purchase } from "./purchase";
 import { formatDateStandard } from "../utils/dates";
+import { Authorship } from "~/components/Document/lib/types";
 
 export type ID = string | number | null | undefined;
 export type KeyOf<ObjectType> = keyof ObjectType;
@@ -101,6 +102,7 @@ export type AuthorProfile = {
   orcid?: OrcidConnect;
   openAlexIds: Array<string>;
   education: Array<Education>;
+  authorship?: Authorship;
 };
 
 /**
@@ -326,6 +328,12 @@ export const parseAuthorProfile = (raw: any): AuthorProfile => {
 
   if (!parsed.firstName) {
     parsed.firstName = "N/A";
+  }
+
+  if (raw.authorship) {
+    parsed.authorship = {} as Authorship;
+    parsed.authorship.authorPosition = raw.authorship.position;
+    parsed.authorship.isCorresponding = raw.authorship.is_corresponding;
   }
 
   return parsed;


### PR DESCRIPTION
- Refactored references to `authorship` to rely on new data structure explained https://github.com/ResearchHub/researchhub-backend/pull/1822
- Removed requirement of sending authorship ID when opening a claim