### PR TITLE
Reduce APM transaction sample rate to 10%

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -49,6 +49,8 @@ if (process.env.ELASTIC_APM_URL) {
 
     // Set service version (required for sourcemap feature)
     serviceVersion: process.env.SENTRY_RELEASE,
+
+    transactionSampleRate: 0.1,
   });
 }
 


### PR DESCRIPTION
The default transaction sample rate for the Elastic APM client is 100% which is not needed. This change reduces the sample rate to 10% (aligning with the backend configuration applied a few months back).

See: https://www.elastic.co/guide/en/apm/agent/rum-js/current/configuration.html#transaction-sample-rate