### PR TITLE
Use API URL for websockets in staging

### DIFF
--- a/components/withWebSocket.js
+++ b/components/withWebSocket.js
@@ -11,8 +11,7 @@ const ALLOWED_ORIGINS = [
   "backend.prod.researchhub.com",
   "wss://backend.prod.researchhub.com",
   "backend.staging.researchhub.com",
-  "websocket.staging.researchhub.com",
-  "wss://websocket.staging.researchhub.com",
+  "wss://backend.staging.researchhub.com",
   "researchhub.com",
 ];
 

--- a/config/ws.js
+++ b/config/ws.js
@@ -9,7 +9,7 @@ export const ROUTES = {
 
 function setBaseUrl() {
   if (process.env.REACT_APP_ENV === "staging") {
-    return "wss://websocket.staging.researchhub.com/ws/";
+    return "wss://backend.staging.researchhub.com/ws/";
   } else if (process.env.NODE_ENV === "production") {
     return "wss://backend.prod.researchhub.com/ws/";
   } else {


### PR DESCRIPTION
Switch back to API URL for websocket communication. Dedicated websocket hosts are not needed.