### PR TITLE
Shorten displayed document count

### DIFF
--- a/components/UnifiedDocFeed/FeedInfoCard.tsx
+++ b/components/UnifiedDocFeed/FeedInfoCard.tsx
@@ -160,7 +160,6 @@ const styles = StyleSheet.create({
     display: "flex",
     alignItems: "center",
     fontSize: 14,
-    // columnGap: "25px",
     color: "#545161",
     marginTop: 15,
   },
@@ -230,15 +229,11 @@ const styles = StyleSheet.create({
     marginLeft: "auto",
     ":hover": {
       opacity: 1,
-      // borderColor: "red",
-      // color: "red",
     },
   },
   leaveButtonStyle: {
     ":hover": {
       opacity: 1,
-      // borderColor: "red",
-      // color: "red",
     },
   },
 });

--- a/components/UnifiedDocFeed/FeedInfoCard.tsx
+++ b/components/UnifiedDocFeed/FeedInfoCard.tsx
@@ -2,7 +2,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { breakpoints } from "~/config/themes/screen";
 import { css, StyleSheet } from "aphrodite";
 import { isEmpty } from "~/config/utils/nullchecks";
-import { ReactElement, ReactNode, useEffect, useState } from "react";
+import { ReactElement, useEffect, useState } from "react";
 import AuthorFacePile from "../shared/AuthorFacePile";
 import Image from "next/image";
 import { parseHub } from "~/config/types/hub";
@@ -15,23 +15,14 @@ import { formatNumber } from "~/config/utils/number";
 
 type Props = {
   hub: any;
-  hubSubscribeButton?: ReactNode | null;
-  isHomePage: boolean;
   mainHeaderText: string;
 };
 
 export default function FeedInfoCard({
   hub,
-  hubSubscribeButton,
-  isHomePage,
   mainHeaderText,
 }: Props): ReactElement<"div"> | null {
-  const {
-    description,
-    editor_permission_groups = [],
-    hub_image: hubImage,
-    subscriber_count: subCount,
-  } = hub ?? {};
+  const { description, editor_permission_groups = [] } = hub ?? {};
 
   const [userIsSubscribed, setUserIsSubscribed] = useState(false);
   const [hubJoinHovered, setHubJoinedHovered] = useState(false);

--- a/components/UnifiedDocFeed/FeedInfoCard.tsx
+++ b/components/UnifiedDocFeed/FeedInfoCard.tsx
@@ -60,7 +60,6 @@ export default function FeedInfoCard({
     const SUBSCRIBE_API = userIsSubscribed
       ? unsubscribeFromHub
       : subscribeToHub;
-    const hubName = hub.name && capitalize(hub.name);
     SUBSCRIBE_API({ hubId: hub.id }).then((_) =>
       userIsSubscribed ? setUserIsSubscribed(false) : setUserIsSubscribed(true)
     );

--- a/components/UnifiedDocFeed/FeedInfoCard.tsx
+++ b/components/UnifiedDocFeed/FeedInfoCard.tsx
@@ -1,11 +1,9 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { breakpoints } from "~/config/themes/screen";
 import { css, StyleSheet } from "aphrodite";
-import { faUser } from "@fortawesome/free-solid-svg-icons";
-import { isEmpty, nullthrows } from "~/config/utils/nullchecks";
+import { isEmpty } from "~/config/utils/nullchecks";
 import { ReactElement, ReactNode, useEffect, useState } from "react";
 import AuthorFacePile from "../shared/AuthorFacePile";
-import colors, { genericCardColors } from "~/config/themes/colors";
 import Image from "next/image";
 import { parseHub } from "~/config/types/hub";
 import { PaperIcon } from "~/config/themes/icons";
@@ -13,7 +11,6 @@ import { faComments } from "@fortawesome/pro-solid-svg-icons";
 import Button from "../Form/Button";
 import api, { generateApiUrl } from "~/config/api";
 import { subscribeToHub, unsubscribeFromHub } from "~/config/fetch";
-import { capitalize } from "~/config/utils/string";
 import { formatNumber } from "~/config/utils/number";
 
 type Props = {

--- a/components/UnifiedDocFeed/FeedInfoCard.tsx
+++ b/components/UnifiedDocFeed/FeedInfoCard.tsx
@@ -14,6 +14,7 @@ import Button from "../Form/Button";
 import api, { generateApiUrl } from "~/config/api";
 import { subscribeToHub, unsubscribeFromHub } from "~/config/fetch";
 import { capitalize } from "~/config/utils/string";
+import { formatNumber } from "~/config/utils/number";
 
 type Props = {
   hub: any;
@@ -42,8 +43,8 @@ export default function FeedInfoCard({
     (editor_group: any): any => editor_group?.user?.author_profile
   );
   const parsedHub = parseHub(hub);
-  const numPapers = parsedHub.numDocs || 0;
-  const numComments = parsedHub.numComments || 0;
+  const numPapers = formatNumber(parsedHub.numDocs || 0);
+  const numComments = formatNumber(parsedHub.numComments || 0);
   const formattedDescription = (description || "").replace(/\.$/, "");
 
   const getUserIsSubscribedToHub = async () => {

--- a/components/UnifiedDocFeed/UnifiedDocFeedContainer.tsx
+++ b/components/UnifiedDocFeed/UnifiedDocFeedContainer.tsx
@@ -161,8 +161,6 @@ function UnifiedDocFeedContainer({
       {isHomePage || isEmpty(hub) ? null : (
         <FeedInfoCard
           hub={hub}
-          hubSubscribeButton={Boolean(hub) ? subscribeButton : null}
-          isHomePage={isHomePage}
           mainHeaderText={formatMainHeader({
             label: hubName ?? "",
             isHomePage,


### PR DESCRIPTION
The paper/discussion count on hub pages is not easily readable:

<img width="1157" alt="image" src="https://github.com/user-attachments/assets/cbe9df27-41bf-49f3-997f-8f9919136aec">

This change aligns the display count to the same format as used on the hub listing page:

<img width="1156" alt="image" src="https://github.com/user-attachments/assets/b7511a6e-ff3f-45ac-9339-eccc83422828">

