### PR TITLE
Sanitize titles in live feed

### DIFF
--- a/components/LiveFeed/Contribution/ContributionEntry.tsx
+++ b/components/LiveFeed/Contribution/ContributionEntry.tsx
@@ -20,6 +20,7 @@ import ContributionHeader from "../Contribution/ContributionHeader";
 import HubTag from "~/components/Hubs/HubTag";
 import { parseHub } from "~/config/types/hub";
 import DocumentHubs from "~/components/Document/lib/DocumentHubs";
+import sanitizeHtml from "sanitize-html";
 
 type Args = {
   entry: Contribution;
@@ -80,7 +81,10 @@ const ContributionEntry = ({
           );
           title = (
             <ALink href={getUrlToUniDoc(item?.source.unifiedDocument)}>
-              {item?.source.unifiedDocument?.document?.title}
+              {sanitizeHtml(item?.source.unifiedDocument?.document?.title, {
+                allowedTags: [],
+                allowedAttributes: {},
+              })}
             </ALink>
           );
         }
@@ -102,7 +106,10 @@ const ContributionEntry = ({
         } else {
           title = (
             <ALink href={getUrlToUniDoc(item.unifiedDocument)}>
-              {item.unifiedDocument?.document?.title}
+              {sanitizeHtml(item.unifiedDocument?.document?.title, {
+                allowedTags: [],
+                allowedAttributes: {},
+              })}
             </ALink>
           );
           body = truncateText(
@@ -146,7 +153,10 @@ const ContributionEntry = ({
             overrideStyle={styles.documentLink}
             href={getUrlToUniDoc(item?.unifiedDocument)}
           >
-            {item?.unifiedDocument?.document?.title ?? item?.title ?? ""}
+            {sanitizeHtml(item?.unifiedDocument?.document?.title ?? item?.title ?? "", {
+                allowedTags: [],
+                allowedAttributes: {},
+              })}
           </ALink>
         );
         break;


### PR DESCRIPTION
This PR addresses the issue in https://github.com/ResearchHub/issues/issues/78. The issue was that live feed titles weren't sanitized like they were on the post page, leading to HTML tags being displayed. This PR addresses the problem by strictly disallowing all tags and attributes. While this solution works locally (see image below), the final implementation may need adjustments.

![image](https://github.com/user-attachments/assets/9019b802-df2a-43ae-96ca-e6ccdc38f3c7)
