### PR TITLE
Stop title-casing hub names

### DIFF
--- a/components/Document/SubmissionDetails.tsx
+++ b/components/Document/SubmissionDetails.tsx
@@ -4,7 +4,6 @@ import { RHUser } from "~/config/types/root_types";
 import AuthorAvatar from "../AuthorAvatar";
 import HubDropDown from "../Hubs/HubDropDown";
 import { timeSince } from "~/config/utils/dates";
-import { toTitleCase } from "~/config/utils/string";
 import { StyleSheet, css } from "aphrodite";
 import ALink from "../ALink";
 import colors from "~/config/themes/colors";
@@ -97,7 +96,7 @@ function SubmissionDetails({
             href={`/hubs/${h.slug}`}
             overrideStyle={styles.hubLink}
           >
-            {" " + toTitleCase(h.name)}
+            {" " + h.name}
           </ALink>
           {index < visibleHubs?.length - 1 ? "," : ""}
         </div>

--- a/components/EditorsDashboard/EditorDashboardCard.tsx
+++ b/components/EditorsDashboard/EditorDashboardCard.tsx
@@ -5,7 +5,6 @@ import { breakpoints } from "~/config/themes/screen";
 import { css, StyleSheet } from "aphrodite";
 import { ID } from "~/config/types/root_types";
 import { timeAgo } from "~/config/utils/dates";
-import { toTitleCase } from "~/config/utils/string";
 import AuthorAvatar from "../AuthorAvatar";
 import colors from "~/config/themes/colors";
 import DesktopOnly from "../DesktopOnly";
@@ -90,7 +89,7 @@ export default function EditorDashboardUserCard({
     is_hub_editor_of: isHubEditorOf,
   } = authorProfile;
   const hubNameTags = (isHubEditorOf ?? [])
-    .map((hub: any): string => toTitleCase(hub?.name ?? ""))
+    .map((hub: any): string => hub?.name ?? "")
     .map((hubName: string, index: number) => (
       <UserRoleTag
         backgroundColor={colors.EDITOR_TAG_BACKGROUND}

--- a/components/HubLeaderDashboard/HubLeaderDashboardCard.tsx
+++ b/components/HubLeaderDashboard/HubLeaderDashboardCard.tsx
@@ -3,7 +3,6 @@ import { buildSlug } from "~/config/utils/buildSlug";
 import { css, StyleSheet } from "aphrodite";
 import { ID } from "~/config/types/root_types";
 import { timeAgo } from "~/config/utils/dates";
-import { toTitleCase } from "~/config/utils/string";
 import colors from "~/config/themes/colors";
 import Image from "next/image";
 import Link from "next/link";
@@ -49,9 +48,7 @@ export default function HubLeaderDashboardCard({
               alt={`${name} Hub`}
               src={hubImage ?? "/static/beaker.svg"}
             />
-            <div className={css(styles.name) + " clamp1"}>
-              {`${toTitleCase(name)}`}
-            </div>
+            <div className={css(styles.name) + " clamp1"}>{name}</div>
           </div>
           <div className={css(styles.contributionSection)}>
             <div className={css(styles.countLabel, styles.submissionLabel)}>

--- a/components/Hubs/HubTag.tsx
+++ b/components/Hubs/HubTag.tsx
@@ -1,4 +1,3 @@
-import { toTitleCase } from "~/config/utils/string";
 import Link from "next/link";
 import { Hub } from "~/config/types/hub";
 import IconButton from "~/components/Icons/IconButton";
@@ -11,7 +10,7 @@ export const HubBadge = ({ name, size }: { name: string; size?: string }) => {
       variant="round"
       overrideStyle={[styles.hubBtn, styles[`hubBtn--${size}`]]}
     >
-      <span className={css(styles.text)}>{toTitleCase(name)}</span>
+      <span className={css(styles.text)}>{name}</span>
     </IconButton>
   );
 };

--- a/components/Modals/EditHubModal.js
+++ b/components/Modals/EditHubModal.js
@@ -14,7 +14,6 @@ import { ModalActions } from "~/redux/modals";
 
 // Config
 import API from "~/config/api";
-import { toTitleCase } from "~/config/utils/string";
 import { Helpers } from "@quantfive/js-web-config";
 import colors from "../../config/themes/colors";
 import FormTextArea from "../Form/FormTextArea";
@@ -40,8 +39,8 @@ class EditHubModal extends Component {
     if (prevHub !== currHub) {
       let hub = this.props.modals.editHubModal.hub;
       this.setState({
-        originalHubName: hub ? toTitleCase(hub.name) : "",
-        hubName: hub ? toTitleCase(hub.name) : "",
+        originalHubName: hub ? hub.name : "",
+        hubName: hub ? hub.name : "",
         hubDescription: hub ? hub.description : "",
       });
     }
@@ -79,7 +78,7 @@ class EditHubModal extends Component {
     ) {
       return;
     }
-    this.setState({ [id]: id === "hubName" ? toTitleCase(value) : value });
+    this.setState({ [id]: value });
   };
 
   UpdateHub = async (hub) => {

--- a/components/SearchSuggestion/SearchAutosuggest.tsx
+++ b/components/SearchSuggestion/SearchAutosuggest.tsx
@@ -14,7 +14,6 @@ import { PostIcon, PaperIcon, QuestionIcon } from "~/config/themes/icons";
 import { CondensedAuthorList } from "../Author/AuthorList";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faGrid2, faNewspaper } from "@fortawesome/pro-solid-svg-icons";
-import { toTitleCase } from "~/config/utils/string";
 import { formatNumber } from "~/config/utils/number";
 import { highlightTextInSuggestion } from "./lib/util";
 import { useEffect, useState } from "react";
@@ -158,7 +157,7 @@ const HubSuggestion = ({
   suggestion: HubSuggestionType;
   searchString?: string;
 }) => {
-  const hubName = toTitleCase(suggestion.hub.name);
+  const hubName = suggestion.hub.name;
   const titleWithHighlightedPortions = highlightTextInSuggestion(
     hubName,
     searchString,
@@ -200,7 +199,7 @@ const JournalSuggestion = ({
   suggestion: HubSuggestionType;
   searchString?: string;
 }) => {
-  const hubName = toTitleCase(suggestion.hub.name);
+  const hubName = suggestion.hub.name;
   const titleWithHighlightedPortions = highlightTextInSuggestion(
     hubName,
     searchString,

--- a/pages/hubs/[slug]/index.js
+++ b/pages/hubs/[slug]/index.js
@@ -14,12 +14,12 @@ function Index({ slug, hub, error, isLiveFeed }) {
       <Head
         title={
           hub
-            ? toTitleCase(hub.name) + " on ResearchHub"
+            ? hub.name + " on ResearchHub"
             : toTitleCase(slug) + " on ResearchHub"
         }
         description={
           hub
-            ? "Discuss and Discover " + toTitleCase(hub.name)
+            ? "Discuss and Discover " + hub.name
             : "Discuss and Discover " + toTitleCase(slug)
         }
       />

--- a/pages/hubs/[slug]/live.tsx
+++ b/pages/hubs/[slug]/live.tsx
@@ -14,12 +14,12 @@ function Index({ slug, hub, error, isLiveFeed }) {
       <Head
         title={
           hub
-            ? toTitleCase(hub.name) + " on ResearchHub"
+            ? hub.name + " on ResearchHub"
             : toTitleCase(slug) + " on ResearchHub"
         }
         description={
           hub
-            ? "Discuss and Discover " + toTitleCase(hub.name)
+            ? "Discuss and Discover " + hub.name
             : "Discuss and Discover " + toTitleCase(slug)
         }
       />


### PR DESCRIPTION
Stop title-casing hub names. Previously, hub names were returned all lowercase by the backend. With https://github.com/ResearchHub/researchhub-backend/pull/1891, the backend will return hub names as-is (mixed-case) which should be preserved as returned.

Closes https://github.com/ResearchHub/issues/issues/117