### PR TITLE
fix: Add link to reputation v2 post

### DIFF
--- a/components/Author/lib/ExpertiseModal.tsx
+++ b/components/Author/lib/ExpertiseModal.tsx
@@ -34,7 +34,7 @@ const ExpertiseModal = ({
             target="_blank"
             overrideStyle={styles.link}
             theme="linkThemeDefault"
-            href="/"
+            href="https://www.researchhub.com/post/3019/reputation-v2-healthy-research-rewards"
           >
             Learn more about our reputation algorithm
           </ALink>

--- a/components/Author/lib/ExpertiseModal.tsx
+++ b/components/Author/lib/ExpertiseModal.tsx
@@ -29,15 +29,7 @@ const ExpertiseModal = ({
         <div className={css(styles.description)}>
           Below is the full hub-specific reputation of {profile.firstName}{" "}
           {profile.lastName}. Reputation is based on a variety of factors
-          including upvotes and citations.{" "}
-          <ALink
-            target="_blank"
-            overrideStyle={styles.link}
-            theme="linkThemeDefault"
-            href="https://www.researchhub.com/post/3019/reputation-v2-healthy-research-rewards"
-          >
-            Learn more about our reputation algorithm
-          </ALink>
+          including upvotes and citations.
         </div>
         <AuthorReputationSection hideBelowValue={1} reputationList={profile.reputationList} />
       </div>


### PR DESCRIPTION
Currently the link "Learn more about our reputation algorithm" point to the homepage. This change updates the link to point to the reputation v2 post (https://www.researchhub.com/post/3019/reputation-v2-healthy-research-rewards).

<img width="1112" alt="image" src="https://github.com/user-attachments/assets/11bfb3f1-bfd9-4ca6-b784-fd764a7fd95c">
