### PR TITLE
fix: Correctly display "member for" period in years, months, days

### DIFF
--- a/config/utils/dates.js
+++ b/config/utils/dates.js
@@ -198,10 +198,10 @@ export function specificTimeSince(date) {
   const years = now.diff(joined, "year");
   joined.add(years, "year");
 
-  const months = now.diff(joined, "month");
+  const months = now.diff(joined.clone().add(years, "years"), "month");
   joined.add(months, "month");
 
-  const days = now.diff(joined, "day");
+  const days = now.diff(joined.clone().add(months, "months"), "day");
 
   let result = [];
 


### PR DESCRIPTION
Take years and months already displayed into account.

So instead of:

> Member since 2 years, 27 months and 851 days

Show this:

> Member since 2 years, 4 months and 1 day

Fixes https://github.com/ResearchHub/issues/issues/122