### PR TITLE
fix: Copy and paste to hub description does not work

### DIFF
--- a/components/Hubs/HubCard.tsx
+++ b/components/Hubs/HubCard.tsx
@@ -10,7 +10,6 @@ import { truncateText } from "~/config/utils/string";
 import { formatNumber } from "~/config/utils/number";
 import { faCheckCircle, faPenToSquare } from "@fortawesome/pro-light-svg-icons";
 import { useState } from "react";
-import EditHubModal from "../Modals/EditHubModal";
 import { ModalActions } from "~/redux/modals";
 import { connect } from "react-redux";
 

--- a/components/Hubs/HubSelect.tsx
+++ b/components/Hubs/HubSelect.tsx
@@ -5,7 +5,7 @@ import HubCard from "~/components/Hubs/HubCard";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faAngleDown, faSearch } from "@fortawesome/pro-light-svg-icons";
 import Menu, { MenuOption } from "~/components/shared/GenericMenu";
-import { use, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { fetchHubSuggestions } from "~/components/SearchSuggestion/lib/api";
 import debounce from "lodash/debounce";
 import useWindow from "~/config/hooks/useWindow";

--- a/components/Modals/EditHubModal.js
+++ b/components/Modals/EditHubModal.js
@@ -29,7 +29,7 @@ class EditHubModal extends Component {
     this.state = {
       ...this.initialState,
     };
-    this.descriptionLimit = 150;
+    this.descriptionLimit = 500;
     this.nameLimit = 50;
   }
 


### PR DESCRIPTION
Copy and pasting longer strings into the hub description field when editing hubs has no effect. This change increases the character limit for the description field from 150 to 500 characters. This is fully supported by the backend (type `TEXT`) and the hub card will continue to display the description truncated to 150 characters.

Fixes https://github.com/ResearchHub/issues/issues/130