### PR TITLE
(Live feed) published -> shared

### DIFF
--- a/components/LiveFeed/Contribution/ContributionHeader.tsx
+++ b/components/LiveFeed/Contribution/ContributionHeader.tsx
@@ -186,7 +186,7 @@ const ContributionHeader = ({ entry, context }: Args) => {
     );
   } else {
     // @ts-ignore
-    actionLabel = <>{` published a ${item?.unifiedDocument?.documentType}`}</>;
+    actionLabel = <>{` shared a ${item?.unifiedDocument?.documentType}`}</>;
   }
 
   const moreOptionsId = `header-more-options-${entry?.contentType?.name}-${entry?.item?.id}`;


### PR DESCRIPTION
"Published" terminology is misleading to researchers because it implies authorship on the related object. "Shared" is more relevant here.