### PR TITLE
Prevent sidebar scrollbar rendering on Mac 16" and other

### DIFF
--- a/components/Home/sidebar/RootLeftSidebar.tsx
+++ b/components/Home/sidebar/RootLeftSidebar.tsx
@@ -747,6 +747,7 @@ const styles = StyleSheet.create({
   },
   footer: {
     paddingBottom: 20,
+    marginTop: 'auto',
   },
   arrowRight: {
     color: "#aaa",
@@ -819,17 +820,22 @@ const styles = StyleSheet.create({
     top: 0,
     background: colors.GREY_ICY_BLUE_HUE,
     zIndex: 2,
-    //borderBottom: `1px solid ${colors.GREY_BORDER}`,
+    paddingBottom: 8,
   },
 
   scrollableContent: {
-    height: 'calc(100vh - 136px)', // Desktop height
+    height: 'calc(100vh - 136px)', // Adjust for header height
     overflowY: 'auto',
     overflowX: 'hidden',
-    [`@media only screen and (max-width: ${breakpoints.large.str})`]: {
-      height: 'auto', // Remove fixed height on mobile
-      overflowY: 'visible', // Disable scrolling on mobile
+    // Hide scrollbar but keep functionality
+    '::-webkit-scrollbar': {
+      width: 0,
+      background: 'transparent',
     },
+    // For Firefox
+    scrollbarWidth: 'none',
+    // For IE/Edge
+    '-ms-overflow-style': 'none',
   },
 });
 


### PR DESCRIPTION
Before:
16" Mac screen showed sidebar scrollbar always 
![image](https://github.com/user-attachments/assets/dff48649-8c8e-49a2-a48f-d8148f875509)
