### PR TITLE
Fix typo in ResearchHub banner

### DIFF
--- a/components/ResearchHubBanner.js
+++ b/components/ResearchHubBanner.js
@@ -74,7 +74,7 @@ class ResearchHubBanner extends Component {
             </span>
           </div>
           <div className={css(styles.subtext, styles.text)}>
-            {`We are bulding an open platform and community whose goal it is to
+            {`We are building an open platform and community whose goal it is to
             accelerate science. `}
             <Link href={"/about"} className={css(styles.readMore)}>
               Read more

--- a/components/UnifiedDocFeed/UnifiedDocFeedContainer.tsx
+++ b/components/UnifiedDocFeed/UnifiedDocFeedContainer.tsx
@@ -65,12 +65,6 @@ function UnifiedDocFeedContainer({
     setUnifiedDocsLoading(false);
   }, []);
 
-  // useEffectUpdateStatesOnServerChanges({
-  //   routePath: routerPathName,
-  //   serverLoadedData,
-  //   setPaginationInfo,
-  // });
-
   const firstLoad = useRef(!isServer() && !unifiedDocuments.length);
   useEffectFetchDocs({
     fetchParams: {
@@ -146,7 +140,6 @@ function UnifiedDocFeedContainer({
   };
 
   const showLoadMoreButton = hasMore;
-  // const renderableUniDoc = unifiedDocuments.slice(0, localPage * 10);
   const cards = getDocumentCard({
     setUnifiedDocuments,
     unifiedDocumentData: unifiedDocuments,


### PR DESCRIPTION
<img width="970" alt="image" src="https://github.com/user-attachments/assets/d3e06f56-0fde-4e13-8caa-c24fa30eb913">
