### PR TITLE
Add check for corresponding author

### DIFF
--- a/components/Document/lib/PaperVersion/PaperVersionModal.tsx
+++ b/components/Document/lib/PaperVersion/PaperVersionModal.tsx
@@ -268,9 +268,12 @@ const PaperVersionModal = ({ isOpen, closeModal, versions = [], action = "PUBLIS
         return !Object.values(contentErrors).some(Boolean);
         
       case "AUTHORS_AND_METADATA":
+        const hasCorrespondingAuthor = authorsAndAffiliations.some(author => author.isCorrespondingAuthor);
         const authorErrors = {
           authors: authorsAndAffiliations.length === 0 
             ? "Add at least one author" 
+            : !hasCorrespondingAuthor
+            ? "Add at least one corresponding author"
             : null,
         };
         setFieldErrors(authorErrors);


### PR DESCRIPTION
At least one author provided in the paper version modal must be the corresponding author. If none is provided, show an error message and don't let the user advance to the next screen.

<img width="679" alt="image" src="https://github.com/user-attachments/assets/ca5b2224-ddc5-4d54-8136-dcb9c78cf490" />
