### PR TITLE
Don't swallow errors when creating paper versions

### DIFF
--- a/components/Document/api/createPaperAPI.ts
+++ b/components/Document/api/createPaperAPI.ts
@@ -66,6 +66,6 @@ export const createPaperAPI = ({
     })
     .catch((error) => {
       console.error("Request Failed:", error);
-      return [];
+      throw error;
     });
 };


### PR DESCRIPTION
When paper versions are created, we currently swallow the errors although there is explicit error handling in the client code.