### PR TITLE
Share session between old and new apps

### DIFF
--- a/components/CKEditor/ELNEditor.js
+++ b/components/CKEditor/ELNEditor.js
@@ -1,7 +1,6 @@
 import API from "~/config/api";
 import Loader from "~/components/Loader/Loader";
 import NotebookHeader from "~/components/Notebook/NotebookHeader";
-import { AUTH_TOKEN } from "~/config/constants";
 import {
   BUNDLE_VERSION,
   CKEditorCS as CKELNEditor,
@@ -19,7 +18,7 @@ import { useRef, useState, useCallback, useEffect } from "react";
 import { useRouter } from "next/router";
 import { unescapeHtmlString } from "~/config/utils/unescapeHtmlString";
 import { isEmpty, isNullOrUndefined } from "~/config/utils/nullchecks";
-import Cookies from "js-cookie";
+import { getAuthToken } from "~/config/utils/auth";
 
 const saveData = async ({
   editor,
@@ -182,9 +181,7 @@ const ELNEditor = ({
                   xhr.setRequestHeader(
                     "Authorization",
                     "Token " +
-                      (typeof window !== "undefined"
-                        ? Cookies.get(AUTH_TOKEN)
-                        : "")
+                      (typeof window !== "undefined" ? getAuthToken() : "")
                   );
                   xhr.send();
                 });
@@ -230,9 +227,7 @@ const ELNEditor = ({
                   headers: {
                     Authorization:
                       "Token " +
-                      (typeof window !== "undefined"
-                        ? Cookies.get(AUTH_TOKEN)
-                        : ""),
+                      (typeof window !== "undefined" ? getAuthToken() : ""),
                   },
                 },
                 collaboration: {

--- a/components/CKEditor/SimpleEditor.js
+++ b/components/CKEditor/SimpleEditor.js
@@ -1,9 +1,8 @@
 import { Fragment, useState, useEffect, useRef } from "react";
-import { AUTH_TOKEN } from "~/config/constants";
 import { StyleSheet, css } from "aphrodite";
 import API from "~/config/api";
 import colors from "../../config/themes/colors";
-import Cookies from "js-cookie";
+import { getAuthToken } from "~/config/utils/auth";
 
 export default function SimpleEditor(props) {
   const {
@@ -37,8 +36,7 @@ export default function SimpleEditor(props) {
       // Headers sent along with the XMLHttpRequest to the upload server.
       headers: {
         Authorization:
-          "Token " +
-          (typeof window !== "undefined" ? Cookies.get(AUTH_TOKEN) : ""),
+          "Token " + (typeof window !== "undefined" ? getAuthToken() : ""),
       },
     },
   };

--- a/components/Modals/NoteTemplateModal.tsx
+++ b/components/Modals/NoteTemplateModal.tsx
@@ -7,7 +7,6 @@ import Button from "~/components/Form/Button";
 import Loader from "~/components/Loader/Loader";
 import Modal from "react-modal";
 import colors from "~/config/themes/colors";
-import Cookies from "js-cookie";
 import { NOTE_GROUPS } from "~/components/Notebook/config/notebookConstants";
 import { StyleSheet, css } from "aphrodite";
 import { breakpoints } from "~/config/themes/screen";
@@ -24,7 +23,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { AUTH_TOKEN } from "~/config/constants";
+import { getAuthToken } from "~/config/utils/auth";
 
 export type TemplateSidebarEntryProps = {
   orgSlug: string;
@@ -200,7 +199,7 @@ export default function NoteTemplateModal({
                   Authorization:
                     "Token " +
                     (typeof window !== "undefined"
-                      ? Cookies.get(AUTH_TOKEN)
+                      ? getAuthToken()
                       : ""),
                 },
               },

--- a/components/withWebSocket.js
+++ b/components/withWebSocket.js
@@ -1,7 +1,6 @@
 import { useState, useEffect, useRef } from "react";
-import { AUTH_TOKEN } from "~/config/constants";
 import { localWarn } from "~/config/utils/nullchecks";
-import Cookies from "js-cookie";
+import { getAuthToken } from "~/config/utils/auth";
 
 const ALLOWED_ORIGINS = [
   "localhost",
@@ -65,7 +64,7 @@ export default function withWebSocket(
 
       if (props.wsAuth) {
         try {
-          token = Cookies.get(AUTH_TOKEN);
+          token = getAuthToken();
 
           // Sometimes the .get operation will return undefined instead of throwing an error.
           // This ensure that websocket connection does not get established with undefined.

--- a/config/api.js
+++ b/config/api.js
@@ -1,5 +1,5 @@
 import { API } from "./api/index";
-import { AUTH_TOKEN } from "../config/constants";
+import { ENV_AUTH_TOKEN } from "../config/utils/auth";
 import { isNullOrUndefined, doesNotExist } from "~/config/utils/nullchecks";
 import { RESEARCHHUB_POST_DOCUMENT_TYPES } from "./utils/getUnifiedDocType";
 import { convertToBackendFilters } from "~/components/UnifiedDocFeed/utils/converToBackendFilters";
@@ -1312,7 +1312,7 @@ const routes = (BASE_URL) => {
 };
 
 const api = API({
-  authTokenName: AUTH_TOKEN,
+  authTokenName: ENV_AUTH_TOKEN,
   apiRoot,
   routes,
 });

--- a/config/api/api.js
+++ b/config/api/api.js
@@ -1,5 +1,4 @@
 import Cookies from "js-cookie";
-import { AUTH_TOKEN } from "../constants";
 import { getAuthToken } from "../utils/auth";
 
 /**

--- a/config/api/api.js
+++ b/config/api/api.js
@@ -1,4 +1,6 @@
 import Cookies from "js-cookie";
+import { AUTH_TOKEN } from "../constants";
+import { getAuthToken } from "../utils/auth";
 
 /**
  * Module define all API paths
@@ -34,7 +36,7 @@ function setupRequestHeaders(noContentType, authTokenName, overrideToken) {
   let token = "";
 
   if (process.browser) {
-    token = Cookies.get(authTokenName);
+    token = getAuthToken();
   }
 
   if (overrideToken && overrideToken !== "undefined") {

--- a/config/auth/ensureAuthenticated.ts
+++ b/config/auth/ensureAuthenticated.ts
@@ -1,5 +1,5 @@
 import nookies from "nookies";
-import { AUTH_TOKEN } from "~/config/constants";
+import { ENV_AUTH_TOKEN } from "~/config/utils/auth";
 import { Helpers } from "@quantfive/js-web-config";
 import API from "~/config/api";
 
@@ -18,7 +18,7 @@ export default async function ensureAuthenticated({
   nextPageContext,
 }: Props): Promise<AuthResponse> {
   const cookies = nookies.get(nextPageContext);
-  const authToken = cookies[AUTH_TOKEN];
+  const authToken = cookies[ENV_AUTH_TOKEN];
 
   let authResponse: Response;
   try {

--- a/config/utils/auth.js
+++ b/config/utils/auth.js
@@ -1,0 +1,48 @@
+import Cookies from "js-cookie";
+import { AUTH_TOKEN } from "../constants";
+
+export const getEnvPrefix = () => {
+  if (process.env.REACT_APP_ENV === "staging") {
+    return "stg";
+  } else if (process.env.NODE_ENV === "production") {
+    return "prod";
+  } else {
+    return "local";
+  }
+};
+
+export const getParentDomain = () => {
+  if (process.env.REACT_APP_ENV === "staging") {
+    return ".staging.researchhub.com";
+  } else if (process.env.NODE_ENV === "production") {
+    return ".researchhub.com";
+  } else {
+    return undefined;
+  }
+};
+
+export const getSharedCookieOptions = (expiryDays = 14) => {
+  const options = {
+    expires: expiryDays,
+    path: "/",
+  };
+
+  const parentDomain = getParentDomain();
+  if (parentDomain) {
+    options.domain = parentDomain;
+    options.secure = true;
+    options.sameSite = "lax";
+  }
+
+  return options;
+};
+
+export const ENV_AUTH_TOKEN = `${getEnvPrefix()}.${AUTH_TOKEN}`;
+
+export const getAuthToken = () => {
+  console.log("NICKDEV - getAuthToken");
+  const currentToken = Cookies.get(AUTH_TOKEN);
+  if (currentToken) return currentToken;
+  const envToken = Cookies.get(ENV_AUTH_TOKEN);
+  return envToken;
+};

--- a/config/utils/auth.js
+++ b/config/utils/auth.js
@@ -40,8 +40,18 @@ export const getSharedCookieOptions = (expiryDays = 14) => {
 export const ENV_AUTH_TOKEN = `${getEnvPrefix()}.${AUTH_TOKEN}`;
 
 export const getAuthToken = () => {
-  const currentToken = Cookies.get(AUTH_TOKEN);
-  if (currentToken) return currentToken;
   const envToken = Cookies.get(ENV_AUTH_TOKEN);
-  return envToken;
+  if (envToken) {
+    Cookies.remove(AUTH_TOKEN);
+    return envToken;
+  }
+
+  const currentToken = Cookies.get(AUTH_TOKEN);
+  if (currentToken) {
+    Cookies.set(ENV_AUTH_TOKEN, currentToken, getSharedCookieOptions());
+    Cookies.remove(AUTH_TOKEN);
+    return currentToken;
+  }
+
+  return null;
 };

--- a/config/utils/auth.js
+++ b/config/utils/auth.js
@@ -40,7 +40,6 @@ export const getSharedCookieOptions = (expiryDays = 14) => {
 export const ENV_AUTH_TOKEN = `${getEnvPrefix()}.${AUTH_TOKEN}`;
 
 export const getAuthToken = () => {
-  console.log("NICKDEV - getAuthToken");
   const currentToken = Cookies.get(AUTH_TOKEN);
   if (currentToken) return currentToken;
   const envToken = Cookies.get(ENV_AUTH_TOKEN);

--- a/pages/[orgSlug]/notebook/[noteId]/index.tsx
+++ b/pages/[orgSlug]/notebook/[noteId]/index.tsx
@@ -5,7 +5,7 @@ import { ROUTES as WS_ROUTES } from "~/config/ws";
 import { useRouter } from "next/router";
 import { fetchNote } from "~/config/fetch";
 import nookies from "nookies";
-import { AUTH_TOKEN } from "~/config/constants";
+import { ENV_AUTH_TOKEN } from "~/config/utils/auth";
 import NextError from "next/error";
 import { Helpers } from "@quantfive/js-web-config";
 import ensureAuthenticated from "~/config/auth/ensureAuthenticated";
@@ -46,7 +46,7 @@ export async function getServerSideProps(ctx) {
 
   // Precondition: User is logged in
   const cookies = nookies.get(ctx);
-  const authToken = cookies[AUTH_TOKEN];
+  const authToken = cookies[ENV_AUTH_TOKEN];
   let response: Response;
   try {
     response = await fetchNote({ noteId: ctx.params.noteId }, authToken)

--- a/pages/[orgSlug]/notebook/index.js
+++ b/pages/[orgSlug]/notebook/index.js
@@ -3,7 +3,7 @@ import Error from "next/error";
 import HeadComponent from "~/components/Head";
 import Notebook from "~/components/Notebook/Notebook";
 import nookies from "nookies";
-import { AUTH_TOKEN } from "~/config/constants";
+import { ENV_AUTH_TOKEN } from "~/config/utils/auth";
 import { Helpers } from "@quantfive/js-web-config";
 import { ROUTES as WS_ROUTES } from "~/config/ws";
 import { captureEvent } from "~/config/utils/events";
@@ -36,7 +36,7 @@ export async function getServerSideProps(ctx) {
   const { orgSlug } = params;
 
   const cookies = nookies.get(ctx);
-  const authToken = cookies[AUTH_TOKEN];
+  const authToken = cookies[ENV_AUTH_TOKEN];
 
   // Create a new note if no notes exist in org, otherwise push to first note.
   let notes = {

--- a/pages/for-you/index.js
+++ b/pages/for-you/index.js
@@ -1,4 +1,4 @@
-import { AUTH_TOKEN } from "~/config/constants";
+import { ENV_AUTH_TOKEN } from "~/config/utils/auth";
 import { fetchUnifiedDocFeed } from "~/config/fetch";
 import { isNullOrUndefined } from "~/config/utils/nullchecks";
 import HubPage from "~/components/Hubs/HubPage";
@@ -13,7 +13,7 @@ const Index = (props) => {
 Index.getInitialProps = async (ctx) => {
   const { query } = ctx;
   const cookies = nookies.get(ctx);
-  const authToken = cookies[AUTH_TOKEN];
+  const authToken = cookies[ENV_AUTH_TOKEN];
   const defaultProps = getFetchDefaults({ query, authToken });
 
   if (process.browser) {

--- a/pages/funding/index.tsx
+++ b/pages/funding/index.tsx
@@ -1,4 +1,4 @@
-import { AUTH_TOKEN } from "~/config/constants";
+import { ENV_AUTH_TOKEN } from "~/config/utils/auth";
 import { fetchUnifiedDocFeed } from "~/config/fetch";
 import { isNullOrUndefined } from "~/config/utils/nullchecks";
 import HubPage from "~/components/Hubs/HubPage";
@@ -30,7 +30,7 @@ const Index: NextPage = (props) => {
 Index.getInitialProps = async (ctx) => {
   const { query } = ctx;
   const cookies = nookies.get(ctx);
-  const authToken = cookies[AUTH_TOKEN];
+  const authToken = cookies[ENV_AUTH_TOKEN];
   const defaultProps = getFetchDefaults({ query, authToken });
 
   try {

--- a/pages/live/index.tsx
+++ b/pages/live/index.tsx
@@ -1,4 +1,4 @@
-import { AUTH_TOKEN } from "~/config/constants";
+import { ENV_AUTH_TOKEN } from "~/config/utils/auth";
 import { fetchUnifiedDocFeed } from "~/config/fetch";
 import { isNullOrUndefined } from "~/config/utils/nullchecks";
 import HubPage from "~/components/Hubs/HubPage";
@@ -24,7 +24,7 @@ const Index: NextPage = (props) => {
 Index.getInitialProps = async (ctx) => {
   const { query } = ctx;
   const cookies = nookies.get(ctx);
-  const authToken = cookies[AUTH_TOKEN];
+  const authToken = cookies[ENV_AUTH_TOKEN];
   const defaultProps = getFetchDefaults({ query, authToken });
 
   if (process.browser) {

--- a/pages/most-discussed/[scope]/index.js
+++ b/pages/most-discussed/[scope]/index.js
@@ -5,7 +5,7 @@ import { fetchPaperFeed } from "~/config/fetch";
 import { filterOptions, scopeOptions } from "~/config/utils/options";
 
 import nookies from "nookies";
-import { AUTH_TOKEN } from "~/config/constants";
+import { ENV_AUTH_TOKEN } from "~/config/utils/auth";
 
 const Index = (props) => {
   return <HubPage home={true} {...props} />;
@@ -16,7 +16,7 @@ Index.getInitialProps = async (ctx) => {
   const { scope, page } = query;
 
   const cookies = nookies.get(ctx);
-  const authToken = cookies[AUTH_TOKEN];
+  const authToken = cookies[ENV_AUTH_TOKEN];
 
   const defaultProps = {
     initialFeed: null,

--- a/pages/most-discussed/index.js
+++ b/pages/most-discussed/index.js
@@ -5,7 +5,7 @@ import { fetchPaperFeed } from "~/config/fetch";
 import { filterOptions } from "~/config/utils/options";
 
 import nookies from "nookies";
-import { AUTH_TOKEN } from "~/config/constants";
+import { ENV_AUTH_TOKEN } from "~/config/utils/auth";
 
 const Index = (props) => {
   return <HubPage home={true} {...props} />;
@@ -16,7 +16,7 @@ Index.getInitialProps = async (ctx) => {
   const { page } = query;
 
   const cookies = nookies.get(ctx);
-  const authToken = cookies[AUTH_TOKEN];
+  const authToken = cookies[ENV_AUTH_TOKEN];
 
   const defaultProps = {
     initialFeed: null,

--- a/pages/newest/[scope]/index.js
+++ b/pages/newest/[scope]/index.js
@@ -5,7 +5,7 @@ import { fetchPaperFeed } from "~/config/fetch";
 import { filterOptions, scopeOptions } from "~/config/utils/options";
 
 import nookies from "nookies";
-import { AUTH_TOKEN } from "~/config/constants";
+import { ENV_AUTH_TOKEN } from "~/config/utils/auth";
 
 const Index = (props) => {
   return <HubPage home={true} {...props} />;
@@ -16,7 +16,7 @@ Index.getInitialProps = async (ctx) => {
   const { scope, page } = query;
 
   const cookies = nookies.get(ctx);
-  const authToken = cookies[AUTH_TOKEN];
+  const authToken = cookies[ENV_AUTH_TOKEN];
 
   const defaultProps = {
     initialFeed: null,

--- a/pages/newest/index.js
+++ b/pages/newest/index.js
@@ -5,7 +5,7 @@ import { fetchPaperFeed } from "~/config/fetch";
 import { filterOptions } from "~/config/utils/options";
 
 import nookies from "nookies";
-import { AUTH_TOKEN } from "~/config/constants";
+import { ENV_AUTH_TOKEN } from "~/config/utils/auth";
 
 const Index = (props) => {
   return <HubPage home={true} {...props} />;
@@ -16,7 +16,7 @@ Index.getInitialProps = async (ctx) => {
   const { page } = query;
 
   const cookies = nookies.get(ctx);
-  const authToken = cookies[AUTH_TOKEN];
+  const authToken = cookies[ENV_AUTH_TOKEN];
 
   const defaultProps = {
     initialFeed: null,

--- a/pages/notebook/index.tsx
+++ b/pages/notebook/index.tsx
@@ -3,7 +3,7 @@
   organization notebook.
 */
 import nookies from "nookies";
-import { AUTH_TOKEN } from "~/config/constants";
+import { ENV_AUTH_TOKEN } from "~/config/utils/auth";
 import { generateApiUrl } from "~/config/api";
 import { fetchUserOrgs } from "~/config/fetch";
 import { captureEvent } from "~/config/utils/events";
@@ -23,7 +23,7 @@ const NotebookPage = ({ errorCode }: Props) => {
 
 export async function getServerSideProps(ctx) {
   const cookies = nookies.get(ctx);
-  const authToken = cookies[AUTH_TOKEN];
+  const authToken = cookies[ENV_AUTH_TOKEN];
   const url = generateApiUrl(`organization/0/get_user_organizations`);
 
   let orgsResponse: Response;

--- a/pages/pulled-papers/index.js
+++ b/pages/pulled-papers/index.js
@@ -4,7 +4,7 @@ import { getInitialScope } from "~/config/utils/dates";
 import { fetchPaperFeed } from "~/config/fetch";
 
 import nookies from "nookies";
-import { AUTH_TOKEN } from "~/config/constants";
+import { ENV_AUTH_TOKEN } from "~/config/utils/auth";
 
 const Index = (props) => {
   return <HubPage home={true} {...props} />;
@@ -15,7 +15,7 @@ Index.getInitialProps = async (ctx) => {
   const { page } = query;
 
   const cookies = nookies.get(ctx);
-  const authToken = cookies[AUTH_TOKEN];
+  const authToken = cookies[ENV_AUTH_TOKEN];
 
   const defaultProps = {
     initialFeed: null,

--- a/pages/recs/index.tsx
+++ b/pages/recs/index.tsx
@@ -1,4 +1,4 @@
-import { AUTH_TOKEN } from "~/config/constants";
+import { ENV_AUTH_TOKEN } from "~/config/utils/auth";
 import HubPage from "~/components/Hubs/HubPage";
 import nookies from "nookies";
 import { getFetchDefaults } from "~/components/UnifiedDocFeed/utils/getFetchDefaults";
@@ -20,7 +20,7 @@ const Index: NextPage = (props) => {
 Index.getInitialProps = async (ctx) => {
   const { query } = ctx;
   const cookies = nookies.get(ctx);
-  const authToken = cookies[AUTH_TOKEN];
+  const authToken = cookies[ENV_AUTH_TOKEN];
   const defaultProps = getFetchDefaults({ query, authToken });
 
   if (process.browser) {

--- a/pages/reference-manager/index.tsx
+++ b/pages/reference-manager/index.tsx
@@ -1,4 +1,4 @@
-import { AUTH_TOKEN } from "~/config/constants";
+import { ENV_AUTH_TOKEN } from "~/config/utils/auth";
 import { connect } from "react-redux";
 import { fetchUserOrgs } from "~/config/fetch";
 import { generateApiUrl } from "~/config/api";
@@ -31,7 +31,7 @@ function Index(props) {
 
 export async function getServerSideProps(ctx) {
   const cookies = nookies.get(ctx);
-  const authToken = cookies[AUTH_TOKEN];
+  const authToken = cookies[ENV_AUTH_TOKEN];
   const calloutOpen =
     cookies["callout_open"] === undefined ? null : cookies["callout_open"];
 

--- a/pages/referral/index.js
+++ b/pages/referral/index.js
@@ -12,7 +12,7 @@ import colors from "../../config/themes/colors";
 import FormInput from "../../components/Form/FormInput";
 import ComponentWrapper from "~/components/ComponentWrapper";
 import CustomHead from "~/components/Head";
-import { AUTH_TOKEN } from "~/config/constants";
+import { ENV_AUTH_TOKEN } from "~/config/utils/auth";
 import ReferredUserList from "~/components/Referral/ReferredUserList";
 
 import { breakpoints } from "~/config/themes/screen";
@@ -263,7 +263,7 @@ const mapStateToProps = (state) => ({
 
 export async function getServerSideProps(context) {
   const cookies = nookies.get(context);
-  const authToken = cookies[AUTH_TOKEN];
+  const authToken = cookies[ENV_AUTH_TOKEN];
 
   if (!authToken) {
     return {

--- a/pages/removed/[scope]/index.js
+++ b/pages/removed/[scope]/index.js
@@ -5,7 +5,7 @@ import { fetchPaperFeed } from "~/config/fetch";
 import { scopeOptions } from "~/config/utils/options";
 
 import nookies from "nookies";
-import { AUTH_TOKEN } from "~/config/constants";
+import { ENV_AUTH_TOKEN } from "~/config/utils/auth";
 
 const Index = (props) => {
   return <HubPage home={true} {...props} />;
@@ -16,7 +16,7 @@ Index.getInitialProps = async (ctx) => {
   const { scope, page } = query;
 
   const cookies = nookies.get(ctx);
-  const authToken = cookies[AUTH_TOKEN];
+  const authToken = cookies[ENV_AUTH_TOKEN];
 
   const defaultProps = {
     initialFeed: null,

--- a/pages/removed/index.js
+++ b/pages/removed/index.js
@@ -4,7 +4,7 @@ import { getInitialScope } from "~/config/utils/dates";
 import { fetchPaperFeed } from "~/config/fetch";
 
 import nookies from "nookies";
-import { AUTH_TOKEN } from "~/config/constants";
+import { ENV_AUTH_TOKEN } from "~/config/utils/auth";
 
 const Index = (props) => {
   return <HubPage home={true} {...props} />;
@@ -15,7 +15,7 @@ Index.getInitialProps = async (ctx) => {
   const { page } = query;
 
   const cookies = nookies.get(ctx);
-  const authToken = cookies[AUTH_TOKEN];
+  const authToken = cookies[ENV_AUTH_TOKEN];
 
   const defaultProps = {
     initialFeed: null,

--- a/pages/search/[type]/index.js
+++ b/pages/search/[type]/index.js
@@ -1,4 +1,4 @@
-import { AUTH_TOKEN } from "~/config/constants";
+import { ENV_AUTH_TOKEN } from "~/config/utils/auth";
 import { Fragment } from "react";
 import { Helpers } from "@quantfive/js-web-config";
 import { pickFiltersForApi, QUERY_PARAM } from "~/config/utils/search";
@@ -52,7 +52,7 @@ const Index = ({ apiResponse, hasError }) => {
 
 Index.getInitialProps = async (ctx) => {
   const cookies = nookies.get(ctx);
-  const authToken = cookies[AUTH_TOKEN];
+  const authToken = cookies[ENV_AUTH_TOKEN];
   const filters = pickFiltersForApi({
     searchType: ctx.query.type,
     query: ctx.query,

--- a/pages/top-rated/[scope]/index.js
+++ b/pages/top-rated/[scope]/index.js
@@ -5,7 +5,7 @@ import { fetchPaperFeed } from "~/config/fetch";
 import { filterOptions, scopeOptions } from "~/config/utils/options";
 
 import nookies from "nookies";
-import { AUTH_TOKEN } from "~/config/constants";
+import { ENV_AUTH_TOKEN } from "~/config/utils/auth";
 
 const Index = (props) => {
   return <HubPage home={true} {...props} />;
@@ -16,7 +16,7 @@ Index.getInitialProps = async (ctx) => {
   const { page, scope } = query;
 
   const cookies = nookies.get(ctx);
-  const authToken = cookies[AUTH_TOKEN];
+  const authToken = cookies[ENV_AUTH_TOKEN];
 
   const defaultProps = {
     initialFeed: null,

--- a/pages/top-rated/index.js
+++ b/pages/top-rated/index.js
@@ -5,7 +5,7 @@ import { fetchPaperFeed } from "~/config/fetch";
 import { filterOptions } from "~/config/utils/options";
 
 import nookies from "nookies";
-import { AUTH_TOKEN } from "~/config/constants";
+import { ENV_AUTH_TOKEN } from "~/config/utils/auth";
 
 const Index = (props) => {
   return <HubPage home={true} {...props} />;
@@ -16,7 +16,7 @@ Index.getInitialProps = async (ctx) => {
   const { page } = query;
 
   const cookies = nookies.get(ctx);
-  const authToken = cookies[AUTH_TOKEN];
+  const authToken = cookies[ENV_AUTH_TOKEN];
 
   const defaultProps = {
     initialFeed: null,

--- a/redux/auth.js
+++ b/redux/auth.js
@@ -110,6 +110,16 @@ let getUserHelper = (dispatch, dispatchFetching) => {
     });
 };
 
+const getNewAppBaseUrl = () => {
+  if (process.env.REACT_APP_ENV === "staging") {
+    return "https://www.v2.staging.researchhub.com";
+  } else if (process.env.NODE_ENV === "production") {
+    return "https://new.researchhub.com";
+  } else {
+    return "http://localhost:3000";
+  }
+};
+
 export const AuthActions = {
   /***
    * Login with django-rest-auth
@@ -371,9 +381,20 @@ export const AuthActions = {
           } catch (error) {
             console.error(error);
           }
-          window.location.replace("/");
           Cookies.remove(AUTH_TOKEN);
           Cookies.remove(ENV_AUTH_TOKEN, getSharedCookieOptions());
+          try {
+            const callbackUrl = window.location.origin;
+            const newAppBaseUrl = getNewAppBaseUrl();
+            const logoutUrl = `${newAppBaseUrl}/api/auth/logout?callbackUrl=${encodeURIComponent(
+              callbackUrl
+            )}`;
+
+            // Redirect to the new app's logout endpoint
+            window.location.replace(logoutUrl);
+          } catch (error) {
+            window.location.replace("/");
+          }
         });
     };
   },

--- a/redux/auth.js
+++ b/redux/auth.js
@@ -14,6 +14,13 @@ import { HubActions } from "./hub";
 import Cookies from "js-cookie";
 import * as Sentry from "@sentry/browser";
 import { emptyFncWithMsg } from "~/config/utils/nullchecks";
+import {
+  getEnvPrefix,
+  getParentDomain,
+  getSharedCookieOptions,
+  ENV_AUTH_TOKEN,
+  getAuthToken,
+} from "../config/utils/auth";
 
 export const AuthConstants = {
   LOGIN: "@@auth/LOGIN",
@@ -72,8 +79,9 @@ let getUserHelper = (dispatch, dispatchFetching) => {
       }
 
       if (json.results.length > 0) {
-        const token = Cookies.get(AUTH_TOKEN);
+        const token = getAuthToken();
         Cookies.set(AUTH_TOKEN, token, { expires: 14 });
+        Cookies.set(ENV_AUTH_TOKEN, token, getSharedCookieOptions());
         return dispatch({
           type: AuthConstants.GOT_USER,
           isFetchingUser: false,
@@ -93,6 +101,7 @@ let getUserHelper = (dispatch, dispatchFetching) => {
     .catch((error) => {
       Sentry.captureException(error);
       Cookies.remove(AUTH_TOKEN);
+      Cookies.remove(ENV_AUTH_TOKEN, getSharedCookieOptions());
       dispatch({
         type: AuthConstants.GOT_USER,
         isFetchingUser: false,
@@ -117,6 +126,7 @@ export const AuthActions = {
         .then(Helpers.parseJSON)
         .then((json) => {
           Cookies.set(AUTH_TOKEN, json.token, { expires: 14 });
+          Cookies.set(ENV_AUTH_TOKEN, json.token, getSharedCookieOptions());
           return dispatch({
             type: AuthConstants.LOGIN,
             isLoggedIn: true,
@@ -161,6 +171,7 @@ export const AuthActions = {
         .then(Helpers.parseJSON)
         .then((json) => {
           Cookies.set(AUTH_TOKEN, json.key, { expires: 14 });
+          Cookies.set(ENV_AUTH_TOKEN, json.key, getSharedCookieOptions());
 
           return dispatch({
             type: AuthConstants.REGISTER,
@@ -199,6 +210,7 @@ export const AuthActions = {
         .then(Helpers.parseJSON)
         .then((json) => {
           Cookies.set(AUTH_TOKEN, json.key, { expires: 14 });
+          Cookies.set(ENV_AUTH_TOKEN, json.key, getSharedCookieOptions());
           return dispatch({
             type: AuthConstants.LOGIN,
             isLoggedIn: true,
@@ -245,6 +257,7 @@ export const AuthActions = {
         .then(Helpers.parseJSON)
         .then((json) => {
           Cookies.set(AUTH_TOKEN, json.key, { expires: 14 });
+          Cookies.set(ENV_AUTH_TOKEN, json.key, getSharedCookieOptions());
           return dispatch({
             type: AuthConstants.LOGIN,
             isLoggedIn: true,
@@ -277,6 +290,7 @@ export const AuthActions = {
         .then(Helpers.parseJSON)
         .then((json) => {
           Cookies.set(AUTH_TOKEN, json.key, { expires: 14 });
+          Cookies.set(ENV_AUTH_TOKEN, json.key, getSharedCookieOptions());
           return dispatch({
             type: AuthConstants.LOGIN,
             isLoggedIn: true,
@@ -302,6 +316,7 @@ export const AuthActions = {
   orcidLogin: (params) => {
     return (dispatch) => {
       Cookies.set(AUTH_TOKEN, params["token"], { expires: 14 });
+      Cookies.set(ENV_AUTH_TOKEN, params["token"], getSharedCookieOptions());
       return dispatch({
         type: AuthConstants.LOGIN,
         isLoggedIn: true,
@@ -365,6 +380,7 @@ export const AuthActions = {
           }
           window.location.replace("/");
           Cookies.remove(AUTH_TOKEN);
+          Cookies.remove(ENV_AUTH_TOKEN, getSharedCookieOptions());
         });
     };
   },

--- a/redux/auth.js
+++ b/redux/auth.js
@@ -110,6 +110,8 @@ let getUserHelper = (dispatch, dispatchFetching) => {
     });
 };
 
+// Helper function to get the base URL for the new app.
+// Consider moving this to the envarinment variables
 const getNewAppBaseUrl = () => {
   if (process.env.REACT_APP_ENV === "staging") {
     return "https://www.v2.staging.researchhub.com";

--- a/redux/auth.js
+++ b/redux/auth.js
@@ -80,7 +80,6 @@ let getUserHelper = (dispatch, dispatchFetching) => {
 
       if (json.results.length > 0) {
         const token = getAuthToken();
-        Cookies.set(AUTH_TOKEN, token, { expires: 14 });
         Cookies.set(ENV_AUTH_TOKEN, token, getSharedCookieOptions());
         return dispatch({
           type: AuthConstants.GOT_USER,
@@ -125,7 +124,6 @@ export const AuthActions = {
         .then(Helpers.checkStatus)
         .then(Helpers.parseJSON)
         .then((json) => {
-          Cookies.set(AUTH_TOKEN, json.token, { expires: 14 });
           Cookies.set(ENV_AUTH_TOKEN, json.token, getSharedCookieOptions());
           return dispatch({
             type: AuthConstants.LOGIN,
@@ -170,7 +168,6 @@ export const AuthActions = {
         .then(Helpers.checkStatus)
         .then(Helpers.parseJSON)
         .then((json) => {
-          Cookies.set(AUTH_TOKEN, json.key, { expires: 14 });
           Cookies.set(ENV_AUTH_TOKEN, json.key, getSharedCookieOptions());
 
           return dispatch({
@@ -209,7 +206,6 @@ export const AuthActions = {
         .then(Helpers.checkStatus)
         .then(Helpers.parseJSON)
         .then((json) => {
-          Cookies.set(AUTH_TOKEN, json.key, { expires: 14 });
           Cookies.set(ENV_AUTH_TOKEN, json.key, getSharedCookieOptions());
           return dispatch({
             type: AuthConstants.LOGIN,
@@ -256,7 +252,6 @@ export const AuthActions = {
         .then(Helpers.checkStatus)
         .then(Helpers.parseJSON)
         .then((json) => {
-          Cookies.set(AUTH_TOKEN, json.key, { expires: 14 });
           Cookies.set(ENV_AUTH_TOKEN, json.key, getSharedCookieOptions());
           return dispatch({
             type: AuthConstants.LOGIN,
@@ -289,7 +284,6 @@ export const AuthActions = {
         .then(Helpers.checkStatus)
         .then(Helpers.parseJSON)
         .then((json) => {
-          Cookies.set(AUTH_TOKEN, json.key, { expires: 14 });
           Cookies.set(ENV_AUTH_TOKEN, json.key, getSharedCookieOptions());
           return dispatch({
             type: AuthConstants.LOGIN,
@@ -315,7 +309,6 @@ export const AuthActions = {
    */
   orcidLogin: (params) => {
     return (dispatch) => {
-      Cookies.set(AUTH_TOKEN, params["token"], { expires: 14 });
       Cookies.set(ENV_AUTH_TOKEN, params["token"], getSharedCookieOptions());
       return dispatch({
         type: AuthConstants.LOGIN,


### PR DESCRIPTION
## What?
- Implemented cookie sharing mechanism in the old app to enable cross-application authentication with the new NextJS app
- Maintains backward compatibility while adding support for environment-specific auth tokens

## How?
- Introduces shared auth token utilities in `config/utils/auth.js`:
  - Environment-prefixed token names (e.g., `prod.researchhub.auth.token`)
  - Token priority handling (checks old token first, then env-specific)

- Updates auth token handling:
  - Sets both old and new tokens on login/register
  - Removes both tokens on logout
  - Maintains backward compatibility by keeping original token behavior

- Cookie Configuration:
  - Production: `.researchhub.com`
  - Staging: `.staging.researchhub.com`
  - Local: `localhost`
