### PR TITLE
Render TipTap Mention Blocks in Comments

### DIFF
--- a/components/Comment/Comment.tsx
+++ b/components/Comment/Comment.tsx
@@ -348,7 +348,6 @@ const Comment = ({ comment, document, ignoreChildren }: CommentArgs) => {
                     contentFormat={comment.contentFormat}
                     initiallyExpanded={false}
                     showReadMoreButton={true}
-                    debug={true} // TODO remove after compleating testing
                   />
                 </div>
               </>

--- a/components/Comment/Comment.tsx
+++ b/components/Comment/Comment.tsx
@@ -348,6 +348,7 @@ const Comment = ({ comment, document, ignoreChildren }: CommentArgs) => {
                     contentFormat={comment.contentFormat}
                     initiallyExpanded={false}
                     showReadMoreButton={true}
+                    debug={true} // TODO remove after compleating testing
                   />
                 </div>
               </>

--- a/components/Comment/lib/TipTapRenderer.tsx
+++ b/components/Comment/lib/TipTapRenderer.tsx
@@ -556,7 +556,7 @@ const RenderNode: React.FC<RenderNodeProps> = ({
           href={'/author/' + id}
           target="_blank"
           rel="noopener noreferrer"
-          className={css(styles.mention)}
+          className={css(styles.mentionAuthor)}
         >
           {displayText}
         </a>
@@ -755,7 +755,7 @@ const styles = StyleSheet.create({
     color: colors.BLUE(1),
     cursor: "pointer",
     textDecoration: "none",
-    fontWeight: 500,
+    fontWeight: 400,
     ":hover": {
       textDecoration: "underline",
     },
@@ -766,6 +766,20 @@ const styles = StyleSheet.create({
     cursor: "default",
     ":hover": {
       textDecoration: "underline",
+    },
+  },
+  mentionAuthor: {
+    background: "rgba(57, 113, 255, 0.1)",
+    padding: "2px 4px",
+    borderRadius: 4,
+    textDecoration: "none",
+    color: "#3971ff",
+    cursor: "pointer",
+    fontWeight: 400,
+    transition: "background 0.2s",
+    ":hover": {
+      background: "rgba(57, 113, 255, 0.2)",
+      textDecoration: "none",
     },
   },
 });

--- a/components/Comment/lib/TipTapRenderer.tsx
+++ b/components/Comment/lib/TipTapRenderer.tsx
@@ -755,6 +755,7 @@ const styles = StyleSheet.create({
     color: colors.BLUE(1),
     cursor: "pointer",
     textDecoration: "none",
+    fontWeight: 500,
     ":hover": {
       textDecoration: "underline",
     },


### PR DESCRIPTION
## What?
- This PR introduces support for rendering TipTap mention blocks within the comments.

## How?
- **User/Author** Mentions: Render as clickable `@username` links that navigate to the user’s profile.
- **Paper/Post** Mentions: Render as links to the referenced paper or post.
    > **Note**: For paper and post mentions, links will redirect to the new ResearchHub app. This is because the mention data does not include the document slug, which is required for routing in the current (old) app. As a result, we cannot generate valid old-app URLs for these entities.

<img width="444" alt="image" src="https://github.com/user-attachments/assets/e5e7512d-c655-45e0-a69b-43e9984d0f99" />

