### PR TITLE
Use `is_verified` field instead of `is_verified_v2`

### DIFF
--- a/components/AuthorAvatar.js
+++ b/components/AuthorAvatar.js
@@ -51,19 +51,11 @@ const AuthorAvatar = (props) => {
 
     return (
       <>
-        {showBadgeIfVerified &&
-          !showModeratorBadge &&
-          (author?.is_verified_v2 || author?.isVerified) && (
-            <div
-              style={{ position: "absolute", right: -9, top: -3, zIndex: 1 }}
-            >
-              <VerifiedBadge
-                height={20}
-                width={20}
-                showTooltipOnHover={false}
-              />
-            </div>
-          )}
+        {showBadgeIfVerified && !showModeratorBadge && author?.isVerified && (
+          <div style={{ position: "absolute", right: -9, top: -3, zIndex: 1 }}>
+            <VerifiedBadge height={20} width={20} showTooltipOnHover={false} />
+          </div>
+        )}
         {author && profileImage && !error ? (
           <img
             src={profileImage}

--- a/config/types/root_types.ts
+++ b/config/types/root_types.ts
@@ -317,7 +317,7 @@ export const parseAuthorProfile = (raw: any): AuthorProfile => {
     lastName: raw.last_name,
     url,
     description: raw.description,
-    isVerified: raw.is_verified_v2,
+    isVerified: raw.is_verified,
     headline: raw?.headline?.title || "",
     isHubEditor: raw.is_hub_editor,
     openAlexIds: raw.openalex_ids || [],
@@ -381,7 +381,7 @@ export const parseUser = (raw: any): RHUser => {
     reputation: _raw.reputation,
     createdAt: _raw.created_date,
     balance: _raw.balance,
-    isVerified: _raw.is_verified_v2,
+    isVerified: _raw.is_verified,
     moderator: _raw.moderator,
     createdDate: _raw.created_date
       ? formatDateStandard(_raw.created_date, "MM-DD-YYYY")


### PR DESCRIPTION
`is_verified_v2` was introduced to reflect the new verification status using Persona. It replaces the previous `is_verified` and no longer needs to be referenced explicitly with the `v2` suffix.